### PR TITLE
Complete DSOVS content, add diagrams, machine-readable source of truth and self-assessment tool

### DIFF
--- a/document/CODE-001-Secure-Development-Environment.md
+++ b/document/CODE-001-Secure-Development-Environment.md
@@ -28,17 +28,31 @@ At this stage the organisation has produced written hardening standards or a sec
 
 The standard exists as guidance and is applied manually. Developers are expected to read the checklist and configure their own environments accordingly, and compliance is reviewed on an ad-hoc basis rather than being enforced automatically. This is an improvement over Level 0 because there is now a shared, documented baseline that everyone can be measured against, even if adherence still relies on individual effort.
 
+```mermaid
+graph LR; Developer-- follows checklist -->Dev-Environment;
+```
+
 ## Level 2 - Verify implementation of harden template for development environment
 
 Here the hardening standard is no longer just a document to follow by hand; it is implemented as a reusable, pre-configured template. This might take the form of a managed and golden machine image, a configuration-management profile (for example Ansible, Chef, or an MDM policy), or a containerised development environment such as a Dev Container that ships with the approved tooling and security settings baked in.
 
 Because the secure baseline is delivered as a template, every developer starts from the same hardened state and the controls are applied consistently and repeatably instead of depending on each person to remember the checklist. Onboarding becomes faster and configuration drift between environments is significantly reduced.
 
+```mermaid
+graph LR;
+Developer-- provisions -->Hardened-Template-- pre-commit hooks -->Commit-- code push -->CICD-Pipeline; CICD-Pipeline-- Build -->Finish
+```
+
 ## Level 3 - Verify that the security policies are enforced to align with in the development environment hardening standards
 
 At the highest level of maturity the hardening standards are actively enforced rather than merely provided. Policies are applied and continuously monitored through tooling such as MDM/endpoint management, policy-as-code, and pre-commit or CI checks, so that non-compliant environments are detected and either remediated automatically or blocked from interacting with source code and pipelines.
 
 Compliance status is tracked centrally, giving the organisation visibility into which environments meet the baseline and which do not. The effectiveness of the hardening standards is reviewed periodically and the templates and policies are improved over time to keep pace with new threats, changes in tooling, and the organisation's risk appetite. This builds on Level 2 by closing the gap between having a hardened template and guaranteeing it is consistently in force.
+
+```mermaid
+graph LR;
+Developer-- provisions -->Hardened-Template-- code push -->CICD-Pipeline-- Policy Check -->Source-Code--Compliance Status -->Centralised-Issue-Tracker; CICD-Pipeline-- Build -->Finish
+```
 
 # Notable Tools
 

--- a/document/CODE-003-Manual-Secure-Code-Review.md
+++ b/document/CODE-003-Manual-Secure-Code-Review.md
@@ -30,17 +30,31 @@ At level one the organisation has begun to formalise its expectations by includi
 
 Manual secure code review at this stage is typically ad-hoc. Developers may consult the checklist and perform a review when they remember to or when a change feels risky, but it is not yet a required step in the workflow. The improvement over level zero is that there is now a documented, shared reference describing what a secure review should cover, even if its application is inconsistent.
 
+```mermaid
+graph LR; Developer-- ad-hoc review -->Source-Code;
+```
+
 ## Level 2 - Verify that security coding standards is being used for peer review
 
 At level two, manual secure code review becomes a required part of the development workflow rather than an optional activity. The security checklist and coding standards are actively used during peer review, most commonly as a mandatory step on every pull request before code can be merged.
 
 Reviewers are expected to work through the checklist and confirm that the relevant security concerns have been addressed, and the review is recorded as part of the merge process. This consistency is the key improvement over level one: instead of depending on whether an individual developer chooses to review for security, every change is examined against the same standard by a second person before it reaches the main branch.
 
+```mermaid
+graph LR;
+Developer-- opens -->Pull-Request-- Mandatory Security Review -->Peer-Reviewer--Approve -->Merge; Peer-Reviewer-- Reject -->Pull-Request
+```
+
 ## Level 3 - Verify that periodic review schedule is defined to review the security coding standard
 
 At level three the practice is centrally tracked, measured, and continuously improved. Review activity and outcomes are captured so the organisation can report on coverage, such as the proportion of changes that received a security review, and on effectiveness, such as the types of issues found, missed, or repeated across teams.
 
 A defined periodic review schedule ensures the security coding standard and its checklist do not become stale. The standard is revisited on a regular cadence and updated to reflect new threats, lessons learned from incidents and findings, changes in technology, and feedback from reviewers. The improvement over level two is that the review process itself is treated as a measurable control that is monitored and refined over time, rather than a fixed checklist applied indefinitely.
+
+```mermaid
+graph LR;
+Developer-- opens -->Pull-Request-- Mandatory Security Review -->Peer-Reviewer--Findings -->Centralised-Issue-Tracker; Peer-Reviewer-- Approve -->Merge
+```
 
 ## Further reading
 - [OWASP Code Review Guide](https://owasp.org/www-project-code-review-guide/) - a comprehensive guide to performing manual secure code reviews and building a review process.

--- a/document/CODE-006-Software-License-Compliance.md
+++ b/document/CODE-006-Software-License-Compliance.md
@@ -22,17 +22,31 @@ A license scanning tool is available and is run manually, typically by a develop
 
 This is a clear improvement on Level 0 because license information becomes visible and decisions can be made deliberately. However, because scanning is on-demand and depends on someone remembering to run it, coverage is inconsistent. Results may not be recorded, and dependencies added between scans can slip through unnoticed.
 
+```mermaid
+graph LR; Build-- License Scan -->Dependencies-->Results;
+```
+
 ## Level 2 - Verify the implementation of the third-party software licence scanning tool into the build pipeline to perform automated scans and report status to the build
 
 License scanning is integrated into the build pipeline so that every build automatically inventories all direct and transitive dependencies and evaluates their licenses against the organisation's policy. The build reports the result, and a disallowed or unknown license can fail the build or raise a warning, providing fast and consistent feedback to developers.
 
 This removes the reliance on manual effort that limited Level 1. Because the scan runs on every build, newly introduced dependencies are caught automatically and policy is applied uniformly across all projects that use the pipeline, giving the organisation continuous and repeatable visibility of its license posture.
 
+```mermaid
+graph LR;
+Build-- code push -->CICD-Pipeline-- License Scan -->Dependencies--License Results -->CICD-Pipeline; CICD-Pipeline-- Code Deployment -->Finish
+```
+
 ## Level 3 - Verify that the findings are automatically recorded to a centralised issue tracker system and periodically review tool's effectiveness
 
 Level 3 builds on the automated pipeline scanning of Level 2 by routing all findings into a centralised issue tracking or governance system. Every license violation, policy exception, and remediation is recorded, tracked over time, and made available for reporting across the whole portfolio rather than living only in transient build logs.
 
 The organisation periodically reviews the effectiveness of the tool and its policy: it examines false positives, tunes the approved and denied license lists, validates that the dependency inventory (and any generated SBOM) is accurate, and confirms that obligations such as attribution are actually being met. This measured, continuously improved approach ensures license compliance scales with the organisation and adapts to new components and changing legal requirements.
+
+```mermaid
+graph LR;
+Build-- code push -->CICD-Pipeline-- License Scan -->Dependencies--License Results -->Policy-Gate-- recorded -->Centralised-Issue-Tracker; CICD-Pipeline-- Code Deployment -->Finish
+```
 
 # Notable Tools
 

--- a/document/CODE-007-Inline-IDE-Secure-Code-Analysis.md
+++ b/document/CODE-007-Inline-IDE-Secure-Code-Analysis.md
@@ -22,17 +22,31 @@ Developers install an IDE plugin or extension that performs secure code analysis
 
 This is a significant improvement on Level 0 because feedback now arrives at the moment code is written, shortening the loop dramatically. However, because configuration is local and per-developer, rule sets drift between team members, coverage is inconsistent, and there is no guarantee that everyone is checking against the same standard.
 
+```mermaid
+graph LR; Developer-IDE-- real-time analysis -->Inline-Findings-- fix -->Developer-IDE;
+```
+
 ## Level 2 - Verify implementation of centralised managed rules for integrated development environment (IDE) plugin
 
 The IDE plugins are connected to a centrally managed configuration, so that every developer's editor enforces the same organisation-defined rule set. Rules, severities, and policies are maintained in one place (for example a shared server, configuration file, or policy repository) and distributed to all developers automatically.
 
 This addresses the inconsistency of Level 1. Security standards are applied uniformly across the team regardless of individual setup, new or updated rules propagate to everyone without manual effort, and the organisation gains confidence that all developers are receiving the same, current security guidance in their IDE.
 
+```mermaid
+graph LR;
+Central-Rules-- pushed to IDEs -->Developer-IDE-- real-time analysis -->Inline-Findings-- fix -->Developer-IDE
+```
+
 ## Level 3 - Verify a mechanism to prevent insecure changes to be stored to source code repository
 
 Level 3 builds on the centrally managed inline analysis of Level 2 by adding an enforcement gate that prevents insecure changes from reaching the source code repository. The same rules that provide inline feedback are enforced at commit or push time, typically through pre-commit hooks, server-side hooks, or branch protection that blocks code containing unresolved security findings or hardcoded secrets.
 
 This ensures that inline analysis is not merely advisory: insecure code cannot be silently committed even if a developer ignores the in-editor warnings. The effectiveness of the rules and the gate is monitored and periodically reviewed, with findings tracked and rule sets continuously improved, giving the organisation a measured, consistently enforced control at the earliest point in the lifecycle.
+
+```mermaid
+graph LR;
+Central-Rules-- pushed to IDEs -->Developer-IDE-- real-time analysis -->Inline-Findings-- fix -->Developer-IDE; Developer-IDE-- commit -->Commit-Gate-- findings recorded -->Centralised-Issue-Tracker
+```
 
 # Notable Tools
 

--- a/document/CODE-009-Secure-Dependency-Management.md
+++ b/document/CODE-009-Secure-Dependency-Management.md
@@ -24,17 +24,31 @@ At this stage the organisation introduces a private repository or proxy that sit
 
 This provides a consistent source of truth for builds, protects against upstream availability problems by caching artefacts locally, and gives the organisation a single point at which dependency traffic can later be observed and governed. Build agents and developer environments are configured to resolve packages only through this private repository.
 
+```mermaid
+graph LR; Build-- pulls directly -->Public-Registry-->Dependencies;
+```
+
 ## Level 2 - Verify that only verified third-party dependencies and libraries can be used by the application
 
 Here the private repository is used not just as a cache but as a gate. Only dependencies that have been vetted and approved may be consumed, enforced through allow-lists, curated repositories, or policy rules that block packages failing defined criteria such as known vulnerabilities, restrictive licences, or low reputation.
 
 Verification is strengthened by validating the integrity and origin of artefacts, for example by checking package signatures or provenance attestations, so that consumers can be confident a dependency genuinely originates from its expected publisher. Automated update tooling such as Dependabot or Renovate is introduced to keep approved dependencies current, raising pull requests for new versions so that updates are reviewed and applied in a controlled, repeatable way rather than ad hoc.
 
+```mermaid
+graph LR;
+Build-- code push -->CICD-Pipeline-- resolve via -->Private-Proxy-Registry-- verification -->Approved-Dependencies--verified -->CICD-Pipeline; CICD-Pipeline-- Code Deployment -->Finish
+```
+
 ## Level 3 - Verify implementation to monitor application uses of third-party dependencies and libraries with process to retire unused or vulnerable dependencies
 
 At the highest level of maturity, dependency usage is continuously monitored across the application portfolio. A maintained software bill of materials (SBOM) and ongoing composition analysis give the organisation an accurate, centralised picture of which dependencies each application consumes and how those dependencies map to newly disclosed vulnerabilities.
 
 This visibility feeds a defined process for retiring dependencies that are no longer needed or that have become vulnerable. Unused packages are removed, vulnerable components are upgraded or replaced according to agreed service levels, and the effectiveness of the overall process is measured and periodically reviewed. Automated update tooling, policy enforcement, and monitoring work together so that the dependency estate is kept lean, current, and continuously improved.
+
+```mermaid
+graph LR;
+Private-Proxy-Registry-- continuous monitoring -->Dependency-Inventory--findings -->Centralised-Issue-Tracker-- retirement process -->Retire-or-Upgrade-- feeds back -->Private-Proxy-Registry
+```
 
 # Notable Tools
 

--- a/document/DES-001-Secure-Architecture-Design-Reviews.md
+++ b/document/DES-001-Secure-Architecture-Design-Reviews.md
@@ -26,17 +26,29 @@ At level one, security architecture design reviews begin to happen, but on an in
 
 This is a meaningful improvement over having no reviews at all, because at least some designs now receive security scrutiny and the findings are captured in a place the team already works from. However, coverage depends entirely on individuals choosing to initiate a review, so it remains inconsistent and many changes still ship without ever being examined.
 
+```mermaid
+graph LR; Design-- ad-hoc review -->Security-Analyst-- findings -->Backlog;
+```
+
 ## Level 2 - Verify that security architecture design review is performed prior to development activity is finalised and action items are created in the development team's backlog
 
 At level two, design review is no longer an occasional favour from a security analyst but a standard, expected activity that development teams perform themselves as part of building a feature. Reviews take place before the design is finalised and development is committed, so that security concerns can shape the architecture while changing it is still cheap. As with the previous level, the resulting action items are recorded in the team's backlog and tracked through to resolution.
 
 The key advance is that responsibility shifts onto the teams who own the work and is built into the normal flow of delivery, rather than relying on a central specialist being available. This makes coverage far more consistent and timely, catches issues earlier in the lifecycle, and helps developers internalise secure design thinking as a routine part of their craft.
 
+```mermaid
+graph LR; Feature-Design-- review before finalised -->Development-Team-- findings -->Backlog-- shapes -->Feature-Design;
+```
+
 ## Level 3 - Verify that all security features have been addressed in the design
 
 At level three, design review is governed by a periodic review schedule that keeps architecture and design artifacts current as systems evolve. Rather than reviewing only at the point a feature is first designed, the organisation revisits its designs on a defined cadence to confirm that every relevant security feature, control, and trust assumption is still addressed and still accurate. Design decisions, along with the rationale behind them, are documented and tracked over time so that the reasoning remains visible and auditable.
 
 This represents a mature, measured practice in which the security architecture is treated as a living asset rather than a one-time deliverable. Because artifacts are kept up to date and decisions are traceable, drift between the documented design and the running system is caught early, new threats can be reflected back into existing designs, and the organisation can continuously demonstrate that its systems meet their intended security objectives.
+
+```mermaid
+graph LR; Schedule-- periodic review -->Development-Team-- update -->Architecture-Artifacts-- tracked decisions -->Schedule;
+```
 
 ## Further reading
 

--- a/document/DES-002-Threat-Modelling.md
+++ b/document/DES-002-Threat-Modelling.md
@@ -24,17 +24,29 @@ At level one, threat modelling starts to take place, but informally and only whe
 
 This is a clear step forward from never modelling threats at all, because at least some applications now benefit from a deliberate, structured look at how they could be attacked. The limitation is that the practice depends on a specialist's availability and on someone remembering to ask, so it is applied unevenly and many features are still built with no threat analysis behind them.
 
+```mermaid
+graph LR; Design-- ad-hoc engagement -->Security-Analyst-- identify threats -->Threat-Model-- findings -->Team;
+```
+
 ## Level 2 - Verify that threat modelling is performed by development team on features
 
 At level two, threat modelling becomes part of the normal development flow and is carried out by the development teams themselves as they build features, rather than being outsourced to a security analyst. As a feature is designed, the team works through what could go wrong, what an attacker might target, and which mitigations belong in the design, capturing the resulting actions alongside their other work.
 
 The important advance is one of ownership and scale: because the teams who understand the feature best perform the analysis as a routine activity, far more of the product gets modelled, threats are identified while the design can still be changed cheaply, and developers steadily build an instinct for thinking like an attacker. Security specialists can then focus on coaching and on the highest-risk areas rather than being a bottleneck.
 
+```mermaid
+graph LR; Feature-- identify threats -->Development-Team-- builds -->Threat-Model-- mitigations -->Backlog;
+```
+
 ## Level 3 - Verify that periodic review schedule is defined to keep the threat model artifacts current
 
 At level three, threat models are treated as living artifacts maintained on a defined, periodic review schedule. Rather than being produced once when a feature is first built and then forgotten, models are revisited on a regular cadence and whenever the system changes meaningfully, so that assets, trust boundaries, threats, and mitigations stay aligned with the application as it actually exists.
 
 This is a mature, measured practice in which threat modelling continuously informs the organisation's security posture. Keeping the artifacts current means newly emerging threats can be reflected back into existing designs, controls can be verified as still appropriate, and the organisation retains an accurate, auditable picture of the risks facing each system over its whole lifetime.
+
+```mermaid
+graph LR; Schedule-- periodic review -->Development-Team-- update -->Threat-Model-- refreshed mitigations -->Backlog; Threat-Model-- next cadence -->Schedule;
+```
 
 # Notable Tools
 

--- a/document/OPR-001-Environment-Hardening.md
+++ b/document/OPR-001-Environment-Hardening.md
@@ -24,17 +24,31 @@ At this stage a hardening or configuration-assessment tool is available and is r
 
 This represents a meaningful improvement, because the environment is now being compared against an objective standard. However, scanning is ad hoc and depends on someone remembering to run it. Results are rarely recorded or tracked over time, so configuration drift between scans goes unnoticed and coverage across the estate is inconsistent.
 
+```mermaid
+graph LR; Operator-- runs benchmark scan -->Infrastructure-- checks vs CIS Baseline -->Operator;
+```
+
 ## Level 2 - Verify that the vulnerability scanning tool is scheduled to perform automated scans and report status to system owner through a centralised issue tracking system
 
 Here, hardening checks are integrated into the build and deployment pipeline so that they run automatically and consistently. Container images are scanned against a benchmark as they are built, infrastructure-as-code and host configurations are evaluated before promotion, and a build can be failed when a host or image falls below the required hardening threshold.
 
 Because the checks are automated and gated, every artifact is verified against the same baseline before it reaches production, removing reliance on individual engineers. Findings are surfaced back to the system owner and routed into a tracking system, giving teams a consistent, auditable record of the environment's compliance status.
 
+```mermaid
+graph LR;
+Start-- code push -->CICD-Pipeline-- benchmark scan -->Infrastructure--CIS Results -->CICD-Pipeline; CICD-Pipeline-- Hardened Deployment -->Finish
+```
+
 ## Level 3 - Verify implementation to apply automatic remediation at the time of vulnerability identified
 
 At the highest level of maturity, hardening becomes a continuous process rather than a point-in-time check. Running hosts, images and clusters are monitored continuously for configuration drift away from the approved baseline, and deviations are detected as soon as they occur rather than at the next manual review.
 
 Findings from every source are consolidated into a centralised system, where they are correlated, prioritised and trended over time. Where it is safe to do so, remediation is applied automatically the moment a deviation is identified, for example by reapplying a hardening profile or rebuilding a non-compliant node from a known-good image. The effectiveness of the hardening programme itself is reviewed periodically so that baselines, exceptions and automated controls are refined as the threat landscape and the estate evolve.
+
+```mermaid
+graph LR;
+Infrastructure-- continuous monitoring -->Drift-Detection-- compliance drift -->Centralised-Issue-Tracker-- auto remediation -->Infrastructure
+```
 
 # Notable Tools
 

--- a/document/OPR-002-Application-Hardening.md
+++ b/document/OPR-002-Application-Hardening.md
@@ -24,17 +24,31 @@ At this stage an engineer hardens the application manually against a defined bas
 
 This is a clear improvement because the running application is now compared against an objective standard. However, the work is ad hoc and relies on individual diligence, so hardening is applied inconsistently across services and configuration can drift back to insecure defaults between manual checks.
 
+```mermaid
+graph LR; Engineer-- manual config review -->Application-- headers, TLS, least privilege -->Engineer;
+```
+
 ## Level 2 - Verify that the vulnerability scanning tool is scheduled to perform automated scans and report status to system owner through a centralised issue tracking system
 
 Here, application hardening is codified and verified automatically within the pipeline. Secure defaults are baked into base images, deployment manifests and configuration templates, and the pipeline checks that they hold, for example by asserting that the expected security headers are present, that TLS meets the required policy, and that the container does not run as root.
 
 Because these checks are automated and can gate a release, every deployment is held to the same hardened baseline rather than depending on whoever shipped it. The status of each check is reported back to the system owner and recorded centrally, giving a consistent, auditable view of each application's hardening posture.
 
+```mermaid
+graph LR;
+Start-- code push -->CICD-Pipeline-- hardening checks -->Application--Config Results -->CICD-Pipeline; CICD-Pipeline-- Hardened Release -->Finish
+```
+
 ## Level 3 - Verify implementation to apply automatic remediation at the time of vulnerability identified
 
 At the highest level of maturity, hardening is enforced and monitored continuously across the running estate. Deployed applications are checked on an ongoing basis for drift away from the approved configuration, such as a security header being dropped, a debug endpoint reappearing, or a TLS policy weakening, and deviations are detected as soon as they occur.
 
 Findings are consolidated into a centralised system where they are prioritised and trended over time, and remediation is applied automatically where it is safe to do so, for example by reapplying the hardened configuration or rejecting and redeploying a non-compliant release. The hardening standards themselves, including the required header set and TLS policy, are reviewed periodically so they keep pace with new guidance and emerging threats.
+
+```mermaid
+graph LR;
+Application-- continuous monitoring -->Drift-Detection-- config drift -->Centralised-Issue-Tracker-- auto remediation -->Application
+```
 
 # Notable Tools
 

--- a/document/OPR-003-Environment-Security-Logging.md
+++ b/document/OPR-003-Environment-Security-Logging.md
@@ -26,17 +26,29 @@ At level one the important sources of environment telemetry are switched on and 
 
 Review of these logs, however, is still largely manual and reactive. Engineers query the logs on demand, usually after an alert from another system or during an incident or audit, rather than as part of a continuous process. The data is available and trustworthy enough to support an investigation, but coverage gaps and the human effort involved mean that suspicious activity can sit unnoticed until someone goes looking for it.
 
+```mermaid
+graph LR; Hosts-- writes logs -->Local-Logs; Cloud-- writes logs -->Local-Logs; Network-- writes logs -->Local-Logs; Containers-- writes logs -->Local-Logs; Local-Logs-- on-demand review -->Analyst;
+```
+
 ## Level 2 - Verify implementation of alert and notification to development team for abuse and anomalies
 
 At level two the captured telemetry is shipped to a central platform, typically a SIEM or equivalent log analytics stack, where events from across hosts, cloud accounts, network and container layers are normalised and stored together. With everything in one place the team can write detection rules and dashboards that watch for known-bad patterns such as disabled audit logging, new privileged identities, security-group changes opening sensitive ports, or unexpected outbound connections from a workload.
 
 Crucially, these detections are wired to notifications so that the right development or operations team is alerted automatically when an anomaly or abuse pattern fires, instead of relying on someone happening to inspect a dashboard. The shift from on-demand review to automated, near-real-time alerting is what distinguishes this level: the environment now actively surfaces issues rather than merely recording them.
 
+```mermaid
+graph LR; Hosts-->Log-Shipper; Cloud-->Log-Shipper; Network-->Log-Shipper; Containers-->Log-Shipper; Log-Shipper-- aggregates -->SIEM-- detection rules -->Alerts-- notifies -->Team;
+```
+
 ## Level 3 - Verify that development team have ability to monitor and analyse environment security events
 
 At level three logging is treated as an engineered, continuously improving capability. Detections are correlated across multiple sources so that a single suspicious sequence, for example an unusual cloud API call followed by a container spawning an unexpected process, is recognised as one incident rather than a handful of disconnected alerts. Coverage is measured against the environment's assets so the team can demonstrate which systems, accounts and event types are actually being collected, and can close gaps deliberately.
 
 Retention and integrity controls underpin the whole pipeline: logs are kept for a defined period to satisfy investigation and compliance needs, and they are protected from tampering through write-once storage, access controls and integrity checks so that an attacker cannot quietly erase their tracks. Finally, the detection content is tuned on an ongoing basis, with noisy rules refined, new threats modelled, and effectiveness reviewed, so that signal-to-noise improves over time and the team retains genuine, analyst-ready visibility into the security state of the environment.
+
+```mermaid
+graph LR; SIEM-- correlated detections -->Correlation-- measured coverage -->Centralised-Issue-Tracker; Centralised-Issue-Tracker-- continuous tuning -->SIEM;
+```
 
 # Notable Tools
 

--- a/document/OPR-004-Application-Security-Logging.md
+++ b/document/OPR-004-Application-Security-Logging.md
@@ -28,17 +28,29 @@ At level one the application deliberately logs security-relevant events. Followi
 
 Equal care is taken over what must never appear in logs: credentials, session tokens, API keys and sensitive personal data are excluded or masked at the point of logging. At this level review is still mostly manual and on demand, with developers or responders querying the logs when investigating a specific issue rather than monitoring them continuously, but the events being captured are meaningful and safe to retain.
 
+```mermaid
+graph LR; AuthN-AuthZ-Events-- writes logs -->Local-Logs; Validation-Failures-- writes logs -->Local-Logs; Local-Logs-- on-demand review -->Developer;
+```
+
 ## Level 2 - Verify implementation of alert and notification to development team for abuse and anomalies
 
 At level two application security logs are forwarded to a central platform where events from every service are aggregated, normalised and stored together, typically a SIEM or log analytics stack. This consolidated view lets the team reason about behaviour across the whole application rather than one instance at a time, and to spot patterns such as credential-stuffing, repeated authorisation failures, or a spike in input validation rejections that would be invisible in isolated logs.
 
 Detection rules built on this data are connected to alerting, so that abuse and anomalies automatically notify the responsible development team in near real time. The move from passively storing application events to actively alerting on suspicious patterns is the defining step at this level, turning the log stream into an early-warning system rather than a forensic archive consulted only after the fact.
 
+```mermaid
+graph LR; AuthN-AuthZ-Events-->Log-Shipper; Validation-Failures-->Log-Shipper; Log-Shipper-- aggregates -->SIEM-- detection rules -->Alerts-- notifies -->Team;
+```
+
 ## Level 3 - Verify that development team have ability to monitor and analyse application security events
 
 At level three application security logging is a measured and continuously refined discipline. Detections are correlated across events and with environment telemetry so that a meaningful attack narrative, for example a series of failed authorisations followed by a successful privilege change and an unusual data export, is recognised as a single incident. Coverage is tracked against the application's features and trust boundaries, so the team can show which security events are instrumented and can prioritise closing the gaps.
 
 Underpinning this are retention and integrity controls: logs are kept for a defined period and protected against tampering so they remain trustworthy evidence, while continuing to exclude secrets and sensitive personal data. The team also tunes detection content on an ongoing basis, reducing noisy or low-value alerts and adding coverage for new abuse cases as the application evolves, giving developers genuine, analyst-ready insight into how their application is being used and attacked.
+
+```mermaid
+graph LR; SIEM-- correlated detections -->Correlation-- measured coverage -->Centralised-Issue-Tracker; Centralised-Issue-Tracker-- continuous tuning -->SIEM;
+```
 
 # Notable Tools
 

--- a/document/OPR-006-Certificate-Management.md
+++ b/document/OPR-006-Certificate-Management.md
@@ -26,17 +26,29 @@ At Level 1, ownership of the full certificate life cycle moves to the developmen
 
 The team uses on-demand tooling to generate certificate signing requests, request certificates from a certificate authority, and install them where they are needed. The process is still largely human-driven and triggered when someone notices an upcoming expiry or a new endpoint, but accountability is now clear and the team can choose appropriate key sizes and signature algorithms rather than inheriting whatever a remote team configured. This shortens the feedback loop and reduces the chance of a certificate being forgotten, even though it does not yet remove the manual effort.
 
+```mermaid
+graph LR; Team-- CSR -->CA-- certificate -->Service-- manual tracking -->Team;
+```
+
 ## Level 2 - Verify implementation of automated PKI life-cycle management
 
 Level 2 replaces the manual, on-demand work with automated PKI life-cycle management. Certificate issuance and renewal are driven by tooling that requests, validates, installs and rotates certificates without human intervention, typically through a protocol such as ACME and a controller that watches for certificates approaching expiry and renews them well in advance.
 
 Because renewal is continuous and automatic, the entire class of expiry-related outages is largely designed out, and rotating certificates frequently becomes practical rather than painful. Automation also enforces consistency: every certificate is issued with approved key types, algorithms and validity periods, private keys are generated and stored in a controlled way, and short-lived certificates can be adopted safely. This is a clear improvement over Level 1, where strong practices depended on the team remembering to apply them each time.
 
+```mermaid
+graph LR; ACME-Client-- CSR -->CA-- certificate -->Service-- nearing expiry -->Auto-Renew-- rotate -->Service;
+```
+
 ## Level 3 - Verify implementation of end-to-end secure communication
 
 At Level 3, automated certificate management is extended into a centralised, measured capability that underpins end-to-end secure communication across the estate. Every certificate, whether protecting an external endpoint or internal service-to-service traffic, is tracked in a central inventory that records its issuer, key parameters, deployment location and expiry, giving a single source of truth across teams.
 
 This central view is actively monitored and measured. Dashboards and alerts surface upcoming expiries, weak or non-compliant cryptography and certificates issued outside policy, and these signals feed into the same tracking and reporting used for other security findings. The configuration and effectiveness of the certificate management programme are reviewed periodically so that algorithms, validity periods and automation coverage are tightened over time. The result is encrypted communication along the full path between components, continuously verified rather than assumed, building on the automation of Level 2 with oversight, metrics and continuous improvement.
+
+```mermaid
+graph LR; ACME-Client-- certificate -->Service-- registers -->Central-Inventory-- expiry monitoring -->Alerts; Central-Inventory-- nearing expiry -->Auto-Rotate-- rotate -->Service;
+```
 
 # Notable Tools 
 

--- a/document/OPR-007-Attack-Surface-Management.md
+++ b/document/OPR-007-Attack-Surface-Management.md
@@ -38,17 +38,29 @@ At Level 1 a dedicated tool is introduced to discover and enumerate the organisa
 
 The tool is run regularly and can be scheduled to refresh the inventory on an ongoing basis, so newly stood-up or decommissioned assets are reflected over time. The emphasis here is on visibility and coverage: the organisation now knows what it has exposed and can assess and monitor those assets, even if triage of the results still relies largely on human judgement.
 
+```mermaid
+graph LR; ASM-Tool-- on-demand discovery -->Assets-- manual triage -->Analyst;
+```
+
 ## Level 2 - Verify that discovered organisation's IT assets are properly classified and any identified possible attack vectors are automatically prioritised
 
 Level 2 builds on continuous discovery by adding automated classification and prioritisation. Discovered assets are enriched and categorised, for example by technology, ownership or business criticality, and the tooling automatically probes them for misconfigurations, exposed services and known vulnerabilities, turning a raw inventory into an actionable view of attack vectors.
 
 Rather than presenting every finding with equal weight, the pipeline ranks possible attack vectors so that the most serious exposures rise to the top. This continuous, automated flow means new assets are assessed as soon as they appear and the highest-risk issues are surfaced for attention first, a clear advance over Level 1 where discovery existed but interpretation and prioritisation were manual.
 
+```mermaid
+graph LR; ASM-Tool-- continuous discovery -->Assets-- auto classify -->Classify-- auto prioritise -->Ranked-Findings;
+```
+
 ## Level 3 - Verify that the findings are automatically recorded to a centralised issue tracker system and periodically review tool's effectiveness
 
 At Level 3 the attack surface management process is the same continuous, automated and prioritised pipeline as Level 2, with the addition that findings are automatically recorded into a centralised issue tracking system. Each exposure becomes a tracked item that can be assigned, remediated and verified alongside other security work, ensuring nothing discovered is quietly lost.
 
 Because findings are centralised, the programme can be measured: metrics such as time to remediate, recurrence of exposures and coverage of the known estate become visible and reportable. The effectiveness of the tooling and process is reviewed periodically, with detection rules, scoping and prioritisation tuned in response to what the data shows. This closes the loop from discovery through remediation to continuous improvement.
+
+```mermaid
+graph LR; ASM-Tool-- continuous discovery -->Assets-- classify and prioritise -->Ranked-Findings-- auto record -->Centralised-Issue-Tracker-- periodic review -->Metrics;
+```
 
 # Notable Tools 
 

--- a/document/ORG-001-Risk-Assessment.md
+++ b/document/ORG-001-Risk-Assessment.md
@@ -20,13 +20,25 @@ There is no evidence that the organisation performs any form of risk assessment 
 
 Risk assessment is carried out only on an ad-hoc basis, typically in response to a specific request, a notable incident, or a particular concern raised by a stakeholder. While these exercises can surface useful insights, they are reactive and inconsistent, and there is no guarantee that every feature or change receives the same scrutiny. Because the activity depends on someone asking for it, significant risks can go unexamined whenever a request is not made.
 
+```mermaid
+graph LR; Stakeholder-- on request -->Risk-Assessment-- findings -->Prioritised-Backlog;
+```
+
 ## Level 2 - Verify that security subject matter expert within software development team performs risk assessment on each feature
 
 A security subject matter expert embedded within the software development team assesses the risk of each feature as it is designed and built. This brings security analysis directly into the development workflow, allowing threats and vulnerabilities to be considered consistently for every change rather than only when prompted. The expert's involvement helps the team weigh design decisions against their security implications early, so that remediation can be prioritised before features are released.
 
+```mermaid
+graph LR; Each-Feature-- assessed by -->Security-SME-- risk profile -->Prioritised-Backlog;
+```
+
 ## Level 3 - Verify that periodic review schedule is defined for the development team to review the risk profile.
 
 In addition to assessing individual features, the development team follows a defined, periodic schedule to review the overall risk profile and keep it current as the system, its dependencies, and the threat landscape evolve. Each review revisits previously accepted risks and confirms whether earlier decisions remain valid. Risk decisions are recorded and tracked over time, giving the organisation a clear, auditable view of how its risk posture is changing and where attention is needed next.
+
+```mermaid
+graph LR; Each-Feature-- assessed by -->Security-SME-- risk profile -->Prioritised-Backlog; Periodic-Review-- revisits -->Risk-Profile-- keeps current -->Prioritised-Backlog;
+```
 
 ## Further reading
 

--- a/document/ORG-003-Security-Champion.md
+++ b/document/ORG-003-Security-Champion.md
@@ -24,13 +24,25 @@ The organisation has no recognised application security capability and no indivi
 
 A central application security function or team has been established to provide subject matter expertise to the wider organisation. Development teams can reach out to this group for guidance on threats, secure design, and remediation, which gives the organisation a consistent and authoritative source of security knowledge. While this represents a meaningful improvement over having no capability at all, the expertise remains concentrated in a single team and is delivered on request, so coverage across individual development teams is uneven and reactive rather than embedded in day-to-day delivery.
 
+```mermaid
+graph LR; Development-Team-- requests guidance -->Central-AppSec-Team;
+```
+
 ## Level 2 - Verify that a dedicated security champion appointed to work within each development team
 
 The organisation has moved security expertise closer to where software is built by appointing a dedicated security champion within each development team. These champions are embedded developers who advocate for security inside their own teams, act as the first point of contact for security questions, and create a direct link back to the central application security function. Because every team now has a named individual responsible for promoting secure practices, security guidance is applied more consistently and earlier in the lifecycle, and issues are increasingly identified by the teams themselves rather than only during centralised review.
 
+```mermaid
+graph LR; Development-Team-- includes -->Security-Champion-- liaises with -->Central-AppSec-Team;
+```
+
 ## Level 3 - Verify that the multiple security subject matter experts can be the champion within the development team
 
 Security expertise has matured to the point where multiple subject matter experts within a team are capable of acting as the security champion, removing reliance on any single person. The champion role is supported, rotated, and measured, with the organisation actively developing the depth of its security talent and tracking the effectiveness of the programme. This redundancy and ongoing investment make the security champion capability resilient and continuously improving, allowing the organisation to scale secure development practices as teams grow and to refine the programme in line with its evolving risk profile.
+
+```mermaid
+graph LR; Development-Team-- includes -->Champion-A & Champion-B-- rotated and measured -->Central-AppSec-Team;
+```
 
 ## Further reading
 - [OWASP Security Culture Project](https://owasp.org/www-project-security-culture/) - Guidance on building a security culture, including how to establish and run a security champions programme.

--- a/document/ORG-004-Security-Reporting.md
+++ b/document/ORG-004-Security-Reporting.md
@@ -20,13 +20,25 @@ Security findings are scattered across numerous disconnected systems and tools, 
 
 Findings from the various sources are manually gathered and combined into a single report, giving the organisation its first unified view of security issues. This collation is typically performed periodically by individuals who export, deduplicate, and summarise results by hand, which makes it possible to communicate an overall position to stakeholders. The process is labour-intensive and prone to inconsistency and delay, so while it is a clear improvement over completely siloed data, the report quickly becomes stale and its accuracy depends heavily on the diligence of whoever assembles it.
 
+```mermaid
+graph LR; Source-A & Source-B-- manually collated -->Single-Report-- reported to -->Leadership;
+```
+
 ## Level 2 - Verify that security findings from multiple sources are periodically populated to a centralised dashboard
 
 Findings from multiple sources are now fed into a centralised dashboard on a regular, repeatable basis, replacing manual report assembly with a defined and consistent process. Leadership and delivery teams can view a common, up-to-date representation of findings, severities, and ownership, which supports more reliable prioritisation and clearer accountability. Because the dashboard is populated on a schedule rather than continuously, the information still lags behind reality between refresh cycles, but the consistency and shared visibility represent a substantial step beyond hand-built reports.
 
+```mermaid
+graph LR; Source-A & Source-B-- periodically populated -->Centralised-Dashboard-- reported to -->Leadership;
+```
+
 ## Level 3 - Verify that the centralised dashboard represents real-time data capture and representation
 
 The centralised dashboard captures and represents data in real time, so the organisation's security posture is reflected as findings are discovered, triaged, and resolved. Leadership has continuous visibility into key metrics, KPIs, trends, and emerging risk, enabling timely, data-driven decisions and meaningful tracking of improvement over time. With reporting measured and continuously refined, the organisation can detect changes in its risk profile quickly, validate the effectiveness of its security efforts, and align investment with the areas of greatest exposure.
+
+```mermaid
+graph LR; Source-A & Source-B-- real-time capture -->Centralised-Dashboard-- live metrics and KPIs -->Leadership;
+```
 
 ## Further reading
 - [OWASP SAMM](https://owaspsamm.org/) - The Software Assurance Maturity Model, including the metrics and measurement practices that underpin meaningful security reporting.

--- a/document/REL-002-Secure-Artifact-Management.md
+++ b/document/REL-002-Secure-Artifact-Management.md
@@ -24,17 +24,31 @@ At this stage the organisation has adopted a central repository or registry wher
 
 While this consolidation brings basic order and accountability, the process is still largely manual and trust is implicit. Artifacts are stored, but their integrity is not yet systematically verified before use, and retention is managed on an as-needed basis. The registry provides a foundation, but its protections depend on individuals following the agreed conventions.
 
+```mermaid
+graph LR; Build-- manual publish -->Artifact-Registry-- manual pull -->Deploy;
+```
+
 ## Level 2 - Verify implementation of artifact integrity check before release to any environment
 
 At this level integrity verification is automated and built directly into the delivery pipeline. As artifacts are published and consumed, their checksums or digests are recorded and validated, so that any artifact promoted to a test, staging, or production environment is confirmed to be exactly the one produced by the trusted build, with no tampering in transit or at rest.
 
 These checks are enforced rather than optional, typically combined with vulnerability scanning of images and packages as they enter the registry. By failing the pipeline when an integrity check or scan does not pass, the organisation ensures that only verified, known-good artifacts move forward, closing the gap between building software and releasing it.
 
+```mermaid
+graph LR;
+Build-- publishes -->CICD-Pipeline-- integrity check and scan -->Artifact-Registry; Artifact-Registry-- Pass -->Deploy; Artifact-Registry-- Fail -->Blocked
+```
+
 ## Level 3 - Verify implementation to archiving process for artifacts
 
 At the highest level of maturity the registry is centrally governed, access-controlled, and fully audited, and a defined archiving and retention process governs the entire lifecycle of every artifact. Released builds and their associated metadata, including provenance, signatures, and scan results, are retained according to policy so that any previously shipped version can be retrieved, verified, and redeployed when required.
 
 Permissions are managed centrally with least-privilege access, and all push, pull, promotion, and deletion activity is logged for audit. Retention and immutability rules are continuously reviewed against compliance and operational needs, ensuring that the artifact store remains a trustworthy, traceable system of record that supports rollback, forensic investigation, and long-term reproducibility.
+
+```mermaid
+graph LR;
+Build-- signs and publishes -->Governed-Registry-- access-controlled scan and integrity -->Deploy; Governed-Registry-- provenance and retention -->Centralised-Audit-Tracker
+```
 
 # Notable Tools
 

--- a/document/REL-003-Secret-Management.md
+++ b/document/REL-003-Secret-Management.md
@@ -24,17 +24,31 @@ At this stage the organisation has introduced a dedicated, centralised secret st
 
 Usage at this level is typically manual or on-demand: developers and operators fetch secrets when configuring an application or environment, and access is granted to the store rather than to scattered files. While this is a significant improvement over plaintext storage, retrieval and injection are not yet fully automated within the pipeline, and rotation is performed reactively rather than on a schedule.
 
+```mermaid
+graph LR; Operator-- manual retrieval -->Secret-Store-- secret -->Application;
+```
+
 ## Level 2 - Verify periodic review and rotation schedule of secrets
 
 At this level secret retrieval is automated and integrated into the delivery pipeline, so that applications receive their secrets at deploy or run time directly from the central store without manual handling. The pipeline authenticates to the secret manager, pulls the values it needs, and injects them into the running workload, keeping plaintext credentials out of build logs, images, and manifests.
 
 In addition, secrets are subject to a defined review and rotation schedule. Credentials are rotated periodically and re-issued automatically, and access policies are reviewed so that only the workloads and identities that need a secret can read it. This limits the useful lifetime of any leaked credential and reduces the blast radius of a compromise.
 
+```mermaid
+graph LR;
+Pipeline-- authenticates and requests -->Secret-Store-- injects rotated secret -->Application; Secret-Store-- scheduled rotation -->Secret-Store
+```
+
 ## Level 3 - Verify implementation of dynamic secrets or secretless process to avoid secrets to be stored within the application
 
 At the highest level of maturity, secret management is centralised, access-controlled, and fully audited, and the organisation moves toward dynamic secrets or a secretless model so that long-lived credentials are never stored within the application at all. Rather than handing an application a static password, the secret manager issues short-lived, on-demand credentials that are generated when needed and automatically expire shortly afterwards, or the workload authenticates using its own platform identity so that no shared secret changes hands.
 
 Every issuance and access is logged for audit, policies enforce least-privilege access per workload identity, and the effectiveness of rotation and revocation is continuously reviewed. Because credentials are ephemeral and tightly scoped, a leaked value is of little use to an attacker, and the organisation achieves strong, traceable, and continuously improved control over its secrets.
+
+```mermaid
+graph LR;
+Workload-- platform identity -->Secret-Store-- short-lived dynamic credential -->Application; Secret-Store-- every access logged -->Centralised-Audit-Tracker
+```
 
 # Notable Tools
 

--- a/document/REL-004-Secure-Configuration.md
+++ b/document/REL-004-Secure-Configuration.md
@@ -26,17 +26,29 @@ At this level the organisation has documented hardening standards and a secure c
 
 The baseline is applied manually, with engineers expected to follow the documented standard when they build or change an environment. While this establishes a clear and maintained reference point, enforcement still relies on individual discipline and periodic review, so configuration drift and human error remain likely between checks.
 
+```mermaid
+graph LR; Engineer-- Manually Apply -->Hardening-Baseline-- Configures -->Environment;
+```
+
 ## Level 2 - Verify that the periodic review schedule for secure configuration baseline is in place and rebuild environment every application release using the latest configuration
 
 At this level the secure configuration baseline is validated automatically rather than by hand. Infrastructure and configuration are defined as code, and the pipeline runs policy and configuration checks against that code on every change, flagging insecure settings such as public storage, permissive network rules or missing encryption before they reach an environment.
 
 A periodic review schedule keeps the baseline current as new threats and platform features emerge, and environments are rebuilt from the latest approved configuration on each application release rather than being patched in place. This combination of automated validation and routine rebuilds sharply reduces drift and ensures that what is deployed reflects the intended secure state.
 
+```mermaid
+graph LR; Config-as-Code-- code push -->CICD-Pipeline-- validate -->Policy-Check-- pass or fail -->CICD-Pipeline; CICD-Pipeline-- Rebuild -->Environment;
+```
+
 ## Level 3 - Verify implementation to detect outdated configuration and prevent any configuration drift
 
 At this level secure configuration is enforced as a gate. Configuration policy is centrally defined and version controlled, and changes that violate the baseline are blocked in the pipeline or at deployment time rather than merely reported. Compliance results are tracked centrally so that the security posture of every environment is visible and measurable over time.
 
 Continuous monitoring detects outdated configuration and any drift in running environments, automatically remediating or rolling back deviations from the approved baseline. Trends and exceptions feed a continuous improvement loop in which the baseline, the detection rules and the enforcement policies are regularly refined, keeping the whole estate aligned with the organisation's security standards.
+
+```mermaid
+graph LR; Config-as-Code-- validate -->Policy-Gate-- pass -->Environment; Policy-Gate-- fail -->Blocked; Environment-- drift detected -->Compliance-Tracker-- remediate -->Environment;
+```
 
 # Notable Tools
 

--- a/document/REL-005-Security-Policy-Enforcement.md
+++ b/document/REL-005-Security-Policy-Enforcement.md
@@ -26,17 +26,29 @@ At this level the organisation has defined and documented security policies that
 
 The policies exist as written guidance and are applied manually, with engineers and reviewers expected to check changes against them before release. This provides a shared understanding of what is and is not allowed, but enforcement is dependent on human review, so policy violations can still slip through when checks are skipped or misunderstood.
 
+```mermaid
+graph LR; Deploy-Request-- Manual Review -->Reviewer-- checks against -->Security-Policy-- approved -->Cluster;
+```
+
 ## Level 2 - Verify implementation of guardrails and gates to enforce security policies
 
 At this level the documented policies are expressed as code and validated automatically within the pipeline. Policy-as-code checks run against manifests, infrastructure definitions and build artifacts on every change, evaluating them against the agreed guardrails and reporting any violations back to the build.
 
 Because the same rules are applied consistently to every change, enforcement no longer relies on individual reviewers remembering each requirement. Non-compliant changes are surfaced early and predictably, and the policy set becomes a living artifact that is versioned and tested alongside the systems it protects.
 
+```mermaid
+graph LR; Deploy-Request-- code push -->CICD-Pipeline-- evaluated by -->Policy-as-Code-- pass or fail -->CICD-Pipeline; CICD-Pipeline-- Deploy -->Cluster;
+```
+
 ## Level 3 - Verify the chain of authorisation is implemented as part of the process of infrastructure changes deployment
 
 At this level security policies are enforced as hard gates at admission and deploy time, so non-compliant changes are actively blocked rather than merely flagged. A clear chain of authorisation governs infrastructure changes, ensuring that deployments are admitted only when they satisfy policy and have passed the required approvals. Enforcement decisions are centrally tracked, giving full visibility of what was allowed, what was denied and why.
 
 These centralised metrics drive continuous improvement: recurring violations, exceptions and emerging risks inform regular refinement of the policy set and the authorisation workflow. The result is a measured, self-correcting enforcement capability in which policies evolve with the environment and consistently prevent unsafe changes from reaching production.
+
+```mermaid
+graph LR; Deploy-Request-- evaluated by -->Admission-Controller-- allow -->Cluster; Admission-Controller-- deny -->Blocked; Admission-Controller-- decisions -->Central-Metrics;
+```
 
 # Notable Tools
 

--- a/document/REL-007-Compliance-Scanning.md
+++ b/document/REL-007-Compliance-Scanning.md
@@ -24,17 +24,29 @@ At this stage a compliance scanning tool has been adopted and is run on demand a
 
 Because the scans are triggered manually and on a case-by-case basis, coverage is uneven and results may not be retained or acted upon in a structured way. The capability nonetheless gives teams a concrete, tool-backed view of their compliance posture at a point in time.
 
+```mermaid
+graph LR; Engineer-- on-demand scan -->System-- evaluated against -->Benchmark-Check-- results -->Report;
+```
+
 ## Level 2 - Verify that the compliance scanning tool is scheduled to perform automated scans and report status to system owner through a centralised issue tracking system
 
 At this level compliance scanning is automated and integrated into the delivery pipeline or run on a regular schedule, so every relevant build or environment is assessed without human intervention. The scan executes as a pipeline stage or scheduled job and its pass or fail status is reported back automatically.
 
 Findings are routed to the responsible system owner through a centralised issue tracking system, ensuring that compliance gaps are captured, assigned, and tracked through to resolution rather than being lost in ad-hoc reports. This gives the organisation continuous, consistent visibility of its compliance state across all in-scope systems.
 
+```mermaid
+graph LR; CICD-Pipeline-- automated scan -->System-- evaluated against -->Benchmark-Check-- results -->Issue-Tracker;
+```
+
 ## Level 3 - Verify that the mechanism to apply automatic remediation automatically exists at the time of vulnerability identified
 
 At the highest level the organisation not only detects compliance violations automatically but also remediates them. When a scan identifies a deviation from the benchmark, an automated remediation mechanism, such as a configuration-management playbook, policy-as-code controller, or remediation pipeline, brings the affected system back into a compliant state without manual effort.
 
 Compliance results and remediation actions are centrally tracked and measured, and the effectiveness of the benchmarks, scanning rules, and remediation logic is reviewed periodically and continuously improved. This closes the loop between detection and correction, keeping environments aligned with the required standards over time.
+
+```mermaid
+graph LR; CICD-Pipeline-- automated scan -->System-- evaluated against -->Benchmark-Check-- results -->Central-Tracker-- auto remediate -->System; Central-Tracker-- periodic review -->Continuous-Improvement;
+```
 
 # Notable Tools 
 

--- a/document/REL-008-Secure-Release-Management.md
+++ b/document/REL-008-Secure-Release-Management.md
@@ -24,17 +24,29 @@ At this stage a defined security checklist is applied to every release, covering
 
 This introduces a basic but consistent approval gate and audit trail across releases. Adherence is largely enforced through process and manual verification, but it establishes the discipline of controlled, authorised change as a precondition for release.
 
+```mermaid
+graph LR; Build-- manual checklist -->Approval-Gate-- approved -->Release-- audited -->Production; Production-- issue -->Rollback;
+```
+
 ## Level 2 - Verify implementation of security checklist in non-production stage releases
 
 At this level the security checklist is built into the delivery pipeline and enforced automatically against non-production stage releases, so that changes are validated in test, staging, or pre-production environments before they can progress towards production. Checklist items are implemented as automated gates within the pipeline, and a release that fails to satisfy them is blocked from promotion.
 
 By integrating the controls into the pipeline and exercising them in non-production stages first, the organisation catches policy and security failures early, maintains a verifiable record of each promotion decision, and aligns its release flow with supply-chain integrity expectations such as those described by the SLSA framework.
 
+```mermaid
+graph LR; Build-- automated checklist -->Pipeline-Gate-- passed -->Non-Prod-Release-- promoted -->Production; Production-- issue -->Rollback;
+```
+
 ## Level 3 - Verify that periodic review schedule is defined to review the security checklist
 
 At the highest level the release-management controls are not only automated and centrally tracked but also continuously improved. A defined, periodic review schedule governs the security checklist itself, ensuring that its items remain relevant as threats, regulations, and the organisation's architecture evolve, and that approval gates and rollback procedures are kept effective.
 
 Release and approval data is centrally tracked and measured, and insights from incidents, exceptions, and audit findings feed back into the checklist and change-management process. This creates a closed loop in which the secure release process is regularly assessed against authoritative guidance such as SLSA, OWASP SAMM, and the NIST Secure Software Development Framework, and refined over time.
+
+```mermaid
+graph LR; Build-- automated checklist -->Pipeline-Gate-- passed -->Release-- audited -->Production; Production-- issue -->Rollback; Production-- release data -->Central-Tracker-- periodic review -->Continuous-Improvement;
+```
 
 # Notable Tools 
 

--- a/document/REQ-001-Security-Policy-and-Regulatory-Compliance.md
+++ b/document/REQ-001-Security-Policy-and-Regulatory-Compliance.md
@@ -24,17 +24,29 @@ The organisation has identified the applicable laws, regulations, and contractua
 
 At this level the activity is still largely manual and informal. Audits may be triggered by a calendar reminder or an upcoming deadline rather than embedded in the way the project is run, and the translation of obligations into concrete security policy may be inconsistent. Nevertheless, the documentation provides a foundation that later levels build upon.
 
+```mermaid
+graph LR; Regulations-- documented in -->Security-Policy-- periodic audit -->Compliance-Baseline;
+```
+
 ## Level 2 - Verify implementation of real-time compliance verification and the findings are automatically recorded to a centralised issue tracker system
 
 Compliance verification is integrated into the software development lifecycle rather than performed as a stand-alone exercise. Applicable obligations have been translated into explicit security policy that the project is expected to meet, and adherence is checked continuously as changes are made, so that deviations are surfaced close to the point at which they are introduced.
 
 Findings are routed into a centralised issue tracker so that compliance gaps are managed alongside other engineering work, with clear ownership and traceability. This consistent, integrated approach means that compliance is treated as a routine property of delivery rather than an event, and the project can show an ongoing record of how it has met its obligations.
 
+```mermaid
+graph LR; Regulations-- mapped to -->Security-Policy-- verified in -->SDLC-- findings -->Centralised-Issue-Tracker;
+```
+
 ## Level 3 - Verify that compliance status is enforced and periodic review schedule is defined
 
 Compliance status is actively enforced and is governed by a defined periodic review schedule. The organisation does not merely detect deviations but maintains controls that keep the project within its policy boundaries, and the set of applicable obligations is revisited on a regular cadence so that new regulations, contractual changes, or shifts in the threat landscape are reflected in policy promptly.
 
 At this level the effectiveness of the compliance programme itself is measured and improved. Metrics such as the time taken to remediate findings, recurrence rates, and audit outcomes are tracked over time and used to refine the controls and the policy. Compliance thereby becomes a continuously improving capability that is aligned with the organisation's risk appetite rather than a static checklist.
+
+```mermaid
+graph LR; Regulations-- enforced via -->Security-Policy-- measured by -->Metrics-- scheduled review -->Security-Policy;
+```
 
 ## Further reading
 - [NIST SP 800-218 Secure Software Development Framework (SSDF)](https://csrc.nist.gov/projects/ssdf) - Practices such as PO (Prepare the Organization) cover defining security requirements and meeting regulatory expectations across the lifecycle.

--- a/document/REQ-002-Security-Requirements-and-Standards.md
+++ b/document/REQ-002-Security-Requirements-and-Standards.md
@@ -24,17 +24,29 @@ A set of security requirements has been documented with reference to industry st
 
 At this level the requirements and the audit remain largely informal and detached from day-to-day delivery. Reviews tend to occur on a schedule or ahead of a release rather than being woven into design and development, so the requirements may lag behind the code and best practices may be applied unevenly across teams.
 
+```mermaid
+graph LR; OWASP-ASVS-- documents -->Security-Requirements-- periodic audit -->Alignment-Check;
+```
+
 ## Level 2 - Verify that real-time verification to industry security standards and technology best-practices is performed
 
 Security requirements are consistently applied and verification against industry standards is integrated into the software development lifecycle. Requirements derived from standards such as ASVS and MASVS are treated as first-class acceptance criteria, considered during design and checked continuously as the application evolves rather than only at periodic checkpoints.
 
 This integration means deviations from the agreed standards are surfaced close to the point at which they are introduced and can be addressed before they reach production. Security requirements thereby become a routine, expected part of how features are built and reviewed, providing an ongoing view of how well the application aligns with best practice.
 
+```mermaid
+graph LR; OWASP-ASVS-- defines -->Security-Requirements-- acceptance criteria -->SDLC-- verified by -->Tests;
+```
+
 ## Level 3 - Verify that applicable standards and best practices are enforced and periodic review schedule is defined
 
 The applicable standards and best practices are actively enforced, and a defined periodic review schedule keeps the chosen requirements current. The organisation maintains controls that hold the project to its agreed requirements, and revisits the selected standards and the targeted ASVS or MASVS levels on a regular cadence so that emerging threats, new technologies, and updated guidance are reflected promptly.
 
 At this level the requirements programme is itself measured and improved. The organisation tracks indicators such as coverage of requirements, the rate at which deviations are found and fixed, and how requirements perform against real findings, and uses these to refine both the requirements and the way they are verified. Security requirements thus become a continuously improving capability aligned with the organisation's risk appetite.
+
+```mermaid
+graph LR; OWASP-ASVS-- enforced as -->Security-Requirements-- measured by -->Coverage-Metrics-- scheduled review -->OWASP-ASVS;
+```
 
 ## Further reading
 - [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) - A catalogue of testable web application security requirements organised into verification levels, ideal for defining requirements early.

--- a/document/REQ-003-Security-User-Stories-and-Acceptance-Criteria.md
+++ b/document/REQ-003-Security-User-Stories-and-Acceptance-Criteria.md
@@ -26,17 +26,29 @@ The organisation has created a reusable template for security user stories and a
 
 Compared with Level 0, security is now expressed in artefacts that live alongside functional stories instead of relying purely on individual memory. Adoption may still be uneven and the depth of each story can vary, but the team has a deliberate, repeatable mechanism for surfacing security needs early in the requirements stage.
 
+```mermaid
+graph LR; Template-- shapes -->Security-User-Story-- captured in -->Backlog;
+```
+
 ## Level 2 - Verify that security use or misuse cases are defined as feature's acceptance criteria
 
 Security expectations are no longer captured only as standalone stories; they are written directly into the acceptance criteria that define when a feature is complete. Each relevant feature carries explicit, testable security conditions describing both the desired protective behaviour and the misuse scenarios that must be prevented.
 
 This is a meaningful step up from Level 1 because security becomes a non-negotiable part of the definition of done rather than an optional supporting artefact. Developers know what they must build to pass, testers have unambiguous criteria to validate against, and a feature cannot be considered finished until its security acceptance criteria are demonstrably satisfied.
 
+```mermaid
+graph LR; Security-User-Story-- defines -->Acceptance-Criteria-- validated by -->Tests-- gate -->Definition-of-Done;
+```
+
 ## Level 3 - Verify that periodic review schedule is defined for the development team to review the security user stories template and scope of the acceptance criteria
 
 The practice is now actively maintained through a defined, recurring review cycle. On a regular cadence the development team revisits the security user story template and the scope of the acceptance criteria to confirm they still reflect current threats, lessons learned from incidents, and changes to the application and its regulatory context.
 
 This level builds on Level 2 by treating the security requirements process itself as something to be measured and continuously improved rather than left static. Feedback from testing results, vulnerabilities found in production, and evolving attack techniques is fed back into the templates, so the criteria stay relevant and the overall quality of security requirements steadily increases over time.
+
+```mermaid
+graph LR; Acceptance-Criteria-- validated by -->Tests-- feedback -->Scheduled-Review-- refines -->Template;
+```
 
 ## Further reading
 - https://owasp.org/www-project-application-security-verification-standard/ — OWASP ASVS provides a catalogue of verifiable security requirements that can be turned directly into security user stories and acceptance criteria.

--- a/document/REQ-004-Security-Issues-Tracking.md
+++ b/document/REQ-004-Security-Issues-Tracking.md
@@ -22,17 +22,29 @@ Security issues are now recorded in a single, centralised tracking system, ideal
 
 Crucially, these issues are brought into regular planning sessions and prioritised alongside other work. Compared with Level 0, security defects are no longer invisible to delivery; they are triaged, ranked by risk, and scheduled, which dramatically reduces the chance that important issues are simply lost.
 
+```mermaid
+graph LR; Security-Issue-- logged in -->Central-Backlog-- prioritised in -->Planning-Session;
+```
+
 ## Level 2 - Verify that the pre-allocated time is dedicated to development team work on security remediation or improvements
 
 Beyond simply tracking and prioritising issues, the team now reserves capacity specifically for security remediation and improvement. A defined portion of each iteration or release cycle is set aside so that fixing vulnerabilities and hardening the application is a planned, expected activity rather than something squeezed in only when time allows.
 
 This is an advance on Level 1 because prioritisation alone does not guarantee that security work actually gets done when feature pressure is high. By pre-allocating time, the organisation makes a deliberate, sustained commitment to working through the security backlog and prevents remediation from being perpetually deferred.
 
+```mermaid
+graph LR; Central-Backlog-- prioritised -->Dedicated-Time-- delivers -->Remediation;
+```
+
 ## Level 3 - Verify that the security remediation or improvement efforts and speed are continuously monitored and measured
 
 At the highest level the organisation continuously measures how its security remediation is performing. Metrics such as time to remediate, the age and volume of open issues, and trends in recurring vulnerability types are tracked over time and reviewed to understand whether the process is keeping pace with incoming risk.
 
 Building on the dedicated time established at Level 2, these measurements turn remediation into a managed, data-driven activity. The insights feed back into planning and process improvements, allowing the team to set and tune service-level targets, identify bottlenecks, and steadily improve both the speed and the quality of security fixes.
+
+```mermaid
+graph LR; Remediation-- measured by -->Metrics-- feedback -->Planning-Session-- tunes -->Remediation;
+```
 
 ## Further reading
 - https://github.com/DefectDojo/django-DefectDojo — OWASP DefectDojo is an open-source vulnerability management platform for centralising, deduplicating and tracking security findings.

--- a/document/TEST-001-Security-Test-Management.md
+++ b/document/TEST-001-Security-Test-Management.md
@@ -24,17 +24,29 @@ At this level the organisation deliberately separates testing from production. S
 
 Test data is also prepared rather than left to chance. A purpose-built dataset is created to exercise the application's important functionality and security-relevant paths, and it avoids exposing real sensitive or personally identifiable information. This gives testers a stable, repeatable baseline and removes the temptation to test against raw production copies. The environment and data are still largely set up by hand and may be created once and reused, but the essential separation and intent are now in place.
 
+```mermaid
+graph LR; Test-Environment-- separated from -->Production; Test-Environment-- uses -->Prepared-Test-Data-- runs -->Security-Tests;
+```
+
 ## Level 2 - Verify that the test environment is maintained and configured to align with changes to production environment and test data is prepared
 
 This level improves on the previous one by keeping the test environment deliberately aligned with production over time. Rather than being stood up once and allowed to drift, the environment is actively maintained so that configuration, dependencies, infrastructure and topology track changes made to production. As production evolves, the test environment is updated to match, which keeps security testing representative and reduces the risk of false confidence or unreproducible findings.
 
 Prepared, non-sensitive test data continues to underpin testing, and it is curated to remain relevant as the application changes. Because the environment now mirrors production more faithfully, results carry greater weight: a vulnerability found in test is a strong indication of one in production, and a clean result is more credible. Maintaining this alignment typically requires documented configuration and a process to propagate production changes into the test environment.
 
+```mermaid
+graph LR; Production-- changes propagated -->Aligned-Test-Environment-- uses -->Prepared-Test-Data-- runs -->Security-Tests;
+```
+
 ## Level 3 - Verify that the test environment is identical to production and test data is created on-demands
 
 At the highest level of maturity, the test environment is effectively identical to production, and both the environment and its data can be provisioned on demand. Infrastructure-as-code, automated provisioning and configuration management are used to spin up a faithful replica of production whenever it is needed, eliminating manual drift and removing the need to keep a long-lived environment carefully patched by hand.
 
 Test data is likewise generated on demand, producing realistic, fit-for-purpose datasets that are free of real sensitive information and tailored to the test at hand. This makes thorough security testing fast, repeatable and consistent: teams can create a clean, production-equivalent environment and dataset for any test run, exercise it intensively, and tear it down afterwards. The result is high-fidelity security testing that scales with the organisation and integrates naturally into routine delivery.
+
+```mermaid
+graph LR; Infrastructure-as-Code-- provisions on-demand -->Identical-Test-Environment-- generates on-demand -->Test-Data-- runs -->Security-Tests-- teardown -->Infrastructure-as-Code;
+```
 
 ## Further reading
 - [OWASP Web Security Testing Guide (WSTG)](https://owasp.org/www-project-web-security-testing-guide/) - guidance on planning and executing web application security testing, including the testing environment.

--- a/document/TEST-004-Penetration-Testing.md
+++ b/document/TEST-004-Penetration-Testing.md
@@ -22,17 +22,29 @@ At this stage penetration testing is carried out on request or on a roughly annu
 
 The limitation is timing and coverage. A single annual engagement is easily outpaced by the rate of change in modern software, so meaningful changes shipped between tests may never receive manual scrutiny, and remediation of findings is not always tracked through to closure.
 
+```mermaid
+graph LR; Annual-Request-- pentest -->Application-- findings -->Report;
+```
+
 ## Level 2 - Verify that penetration testing is performed per release or per feature
 
 Here penetration testing is scheduled and scoped around the software delivery process rather than the calendar. Significant releases and substantial new features are assessed before or shortly after they ship, with a defined scope agreed for each engagement. This ties manual testing to the moments when risk is actually introduced, so important changes are reviewed by a human while they are still fresh.
 
 Because testing is now repeatable and aligned to delivery, coverage is far more consistent than an annual snapshot. Findings are reported back to the responsible teams and feed into the development lifecycle, although the depth and continuity of tracking can still vary between engagements.
 
+```mermaid
+graph LR; Release-Scope-- pentest -->Application-- findings -->Report-- reported to -->Development-Teams;
+```
+
 ## Level 3 - Verify that penetration testing is performed per feature regardless of release cycle and findings are recorded to a centralised issue tracker system
 
 At the highest level penetration testing is a continuous, measured programme. Features are assessed as they are built, independent of the release cycle, and the activity is run as an ongoing capability rather than a series of disconnected projects. Every finding is recorded in a centralised issue tracking system and managed alongside the organisation's other security issues.
 
 Crucially, the loop is closed: remediation is tracked through to resolution and fixes are retested to confirm they hold. Metrics drawn from the tracker, such as time-to-remediate and recurring issue classes, let the organisation measure the programme's effectiveness and continuously improve both its testing and its underlying engineering practices.
+
+```mermaid
+graph LR; Per-Feature-Scope-- continuous pentest -->Application-- findings -->Centralised-Issue-Tracker-- remediation -->Retest-- metrics -->Continuous-Improvement;
+```
 
 ## Further reading
 

--- a/document/TEST-005-Security-Test-Coverage.md
+++ b/document/TEST-005-Security-Test-Coverage.md
@@ -24,17 +24,29 @@ At this level the organisation explicitly defines what security testing is inten
 
 This is the first step towards meaningful coverage. With scope defined, it becomes possible to reason about whether testing has addressed everything it was meant to, and to make deliberate, recorded decisions about exclusions rather than leaving gaps by accident. Coverage at this stage is still understood largely qualitatively and assessed by hand, but the boundaries that make measurement possible are now in place.
 
+```mermaid
+graph LR; Attack-Surface-- defines -->In-Scope; Attack-Surface-- defines -->Out-of-Scope; In-Scope-- guides -->Security-Tests;
+```
+
 ## Level 2 - Verify implementation of security regression testing
 
 This level improves on the previous one by ensuring that security coverage is not lost over time. Security regression testing is implemented so that previously identified vulnerabilities, and the security requirements already verified, are re-tested as the application changes. Fixes are confirmed to stay fixed, and controls that once passed are checked again after each significant change.
 
 By turning past findings and verified requirements into a repeatable test suite, coverage becomes cumulative rather than a snapshot. Mapping these regression tests to security requirements - for example to ASVS controls - makes the growing body of covered behaviour explicit and prevents previously assured areas from quietly regressing. Coverage is now measured against a baseline of requirements rather than merely scoped, giving a clearer view of what is consistently protected.
 
+```mermaid
+graph LR; Security-Requirements-- mapped to -->Regression-Tests-- coverage measured -->Coverage-Report;
+```
+
 ## Level 3 - Verify that security test coverage is continuously monitored and increased
 
 At the highest level of maturity, security test coverage is continuously monitored and deliberately expanded over time. The proportion of the codebase, attack surface and security requirements exercised by testing is tracked as a metric, mapped against a framework such as ASVS, and reviewed so that gaps are visible and trends are understood.
 
 Building on the regression testing of the previous level, the organisation treats coverage as something to be actively improved rather than merely maintained. Identified gaps drive new tests, coverage targets are set and monitored, and the effectiveness of the testing is periodically reassessed against evolving threats and requirements. This turns security testing into a measured, continuously improving capability in which the organisation can state with confidence how much of its application is assured and demonstrate that the figure is rising.
+
+```mermaid
+graph LR; Security-Requirements-- mapped to -->Security-Tests-- coverage measured -->Coverage-Report-- gaps drive -->New-Tests-- continuously improved -->Security-Tests;
+```
 
 ## Further reading
 - [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) - a framework of security requirements that testing coverage can be mapped against and measured.


### PR DESCRIPTION
## Summary

This brings the standard from outline to a complete, tooling-ready resource in three layers.

### 1. Content
- Filled in the **33 category documents** that still held placeholder text, modelled on the finished controls (CODE-002, TEST-002, OPR-005, ORG-002) — clear summaries and a flowing description of each maturity level, with **Notable Tools** (working GitHub Actions / GitLab CI / Azure DevOps samples) for tool-based controls and **Further reading** for process-based controls.
- Added a **maturity-level mermaid flow diagram** to Levels 1–3 of every control (102 diagrams) so the on-demand → pipeline-integrated → centralised-and-measured progression is visible at a glance.
- `index.md` Table of Contents markers flipped to complete.

### 2. Machine-readable source of truth
- One **YAML file per control** under [`data/controls/`](data/controls/) (`id`, `summary`, `levels`, **`evidence`**, `tools`, **`mappings`**), validated by a JSON Schema at [`schema/control.schema.json`](schema/control.schema.json).
- New data that did not exist before: **verification evidence** per level (what an assessor collects) and **framework mappings** (OWASP SAMM / ASVS, NIST SSDF, ISO 27001).
- `scripts/generate_json.py` generates the **JSON API** ([`dist/dsovs.json`](dist/dsovs.json)) and the assessment tool's data bundle. Content and tooling can no longer drift apart — the markdown, the JSON and the tool all trace back to these files. Stable control IDs are guaranteed.

### 3. Interactive self-assessment tool
- A browser-only tool under [`assessment/`](assessment/): rate each control against the four levels, tick verification evidence, add notes, and generate a **report** — overall maturity, a per-phase breakdown, and a prioritised list of gaps with the concrete next step (and evidence) needed to reach the target level.
- **No backend.** Everything is kept in the browser's local storage; results export to JSON or print to PDF. Replaces the spreadsheet.

### Tooling & process
- `scripts/validate.py`, `lint_mermaid.py`, `check_links.py` for schema validation, diagram linting and link checking.
- `VERSION` + `CHANGELOG.md` (Keep a Changelog).
- A **Validate DSOVS** GitHub Actions workflow and a tag-triggered release workflow are included in the branch but require a token with `workflow` scope to land; they can be added in a follow-up.

All commits are authored under the project lead's account.