### PR TITLE
Add landing page and in-site control pages; refine the web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ _site/
 .venv/
 __pycache__/
 *.pyc
+
+# Cloudflare / Wrangler (never commit deploy secrets)
+.wrangler/
+.dev.vars
+.dev.vars.*
+wrangler.toml.local
+.env
+.env.*
+node_modules/
+*.log

--- a/assessment/README.md
+++ b/assessment/README.md
@@ -1,35 +1,49 @@
-# DSOVS Self-Assessment Tool
+# DSOVS web app
 
-A small, dependency-free web app for assessing a project or organisation against
-the OWASP DevSecOps Verification Standard (DSOVS).
+A small, dependency-free web app for the OWASP DevSecOps Verification Standard
+(DSOVS): a landing page, a browser-based self-assessment, and a rendered page
+for every control.
 
-- **Runs in the browser, no backend.** Answers are stored in `localStorage` on the
-  user's own device and never leave it.
-- **Generates a report** — overall maturity, a per-phase breakdown, and a
-  prioritised list of gaps with the concrete next step (and verification
-  evidence) required to reach the target level.
-- **Exports** to JSON, or prints to PDF.
+- **Runs in the browser, no backend.** Assessment answers and screenshots are
+  stored on the user's own device (`localStorage` + IndexedDB) and never leave it.
+- **No content drift.** Every page is generated from the same source of truth
+  (`data/controls/*.yaml` -> `assessment/data.js`), so the rendered controls, the
+  self-assessment and the JSON API always agree.
 
-## Using it
-
-Open the published page at `…/assessment/` on the project site, or open
-`assessment/index.html` locally in a browser.
-
-## How it is built
-
-The tool is plain HTML, CSS and JavaScript:
+## Pages
 
 | File | Purpose |
 | ---- | ------- |
-| `index.html` | Page shell |
-| `styles.css` | Styling |
-| `app.js` | Assessment logic, persistence and report generation |
-| `data.js` | **Generated** — `window.DSOVS_DATA`, the full control set |
+| `index.html` | Landing page (overview, use cases, the table of contents) |
+| `assess.html` | Self-assessment tool and report |
+| `control.html?code=CODE-001` | A single control, rendered in this design |
+| `data.js` | **Generated** - `window.DSOVS_DATA`, the full control set |
+| `styles.css` | Shared design tokens, top bar, buttons |
+| `home.css` / `control.css` | Landing / control-page layout |
+| `app.js` / `home.js` / `control.js` | Behaviour for each page |
 
-`data.js` is produced from the source of truth (`data/controls/*.yaml`) by
-`scripts/generate_json.py`, which also writes the standalone JSON API to
-`dist/dsovs.json`. Do not edit `data.js` by hand — regenerate it:
+## Using it
+
+Open the published site, or open `index.html` locally in a browser.
+
+## Regenerating data
+
+`data.js` is produced from the source of truth by `scripts/generate_json.py`,
+which also writes the standalone JSON API to `dist/dsovs.json`. Do not edit
+`data.js` by hand:
 
 ```bash
 python scripts/generate_json.py
 ```
+
+## Deploying (Cloudflare Pages)
+
+The whole app is static, so it deploys to any static host. For Cloudflare Pages
+with Wrangler (needs Node 20+ and `wrangler login` first):
+
+```bash
+wrangler pages deploy assessment --project-name dsovs
+```
+
+Then attach the custom domain in the Cloudflare dashboard. No secrets are stored
+in this repository.

--- a/assessment/app.js
+++ b/assessment/app.js
@@ -48,6 +48,216 @@
       return "<p>" + esc(p.trim()) + "</p>";
     }).join("");
   }
+  function restParas(text) {
+    var ps = String(text || "").split(/\n\s*\n/).map(function (s) { return s.trim(); }).filter(Boolean);
+    return ps.slice(1).map(function (p) { return "<p>" + esc(p) + "</p>"; }).join("");
+  }
+  function firstSentence(text) {
+    var s = String(text || "").trim().split(/\n/)[0];
+    var m = s.match(/^[\s\S]*?[.!?](\s|$)/);
+    return (m ? m[0] : s).trim();
+  }
+  /* short, commit-style id derived from the assessment content (changes when answers change) */
+  function shortHash(str) {
+    var h1 = 0x811c9dc5 >>> 0;
+    for (var i = 0; i < str.length; i++) { h1 ^= str.charCodeAt(i); h1 = Math.imul(h1, 0x01000193) >>> 0; }
+    var h2 = (0x9e3779b1 ^ str.length) >>> 0;
+    for (var j = 0; j < str.length; j++) { h2 = Math.imul((h2 ^ str.charCodeAt(j)) >>> 0, 0x85ebca77) >>> 0; }
+    return (h1.toString(36) + h2.toString(36)).slice(0, 9);
+  }
+  function currentReportId() { return shortHash(JSON.stringify(state)); }
+
+  var SHORT_PHASE = {
+    "Organisation": "Org", "Requirements": "Req", "Design": "Design",
+    "Code/Build": "Code", "Test": "Test", "Release/Deploy": "Release", "Operate/Monitor": "Operate",
+  };
+  function shortPhase(p) { return SHORT_PHASE[p] || p; }
+  function maturityWord(v) {
+    if (v == null) return "";
+    if (v < 0.75) return "early-stage";
+    if (v < 1.75) return "developing";
+    if (v < 2.5) return "established";
+    return "advanced";
+  }
+  function lerpShade(t) {
+    t = Math.max(0, Math.min(1, t));
+    var a = [224, 224, 229], b = [29, 29, 31];
+    var r = Math.round(a[0] + (b[0] - a[0]) * t);
+    var g = Math.round(a[1] + (b[1] - a[1]) * t);
+    var bl = Math.round(a[2] + (b[2] - a[2]) * t);
+    return "rgb(" + r + "," + g + "," + bl + ")";
+  }
+  function pipelineFlow(rows) {
+    var stages = rows.map(function (r, i) {
+      var has = r.avg != null;
+      var t = has ? r.avg / 3 : 0;
+      var bg = has ? lerpShade(t) : "var(--bg-subtle)";
+      var col = has ? (t > 0.55 ? "#fff" : "var(--text)") : "var(--text-3)";
+      var arrow = i < rows.length - 1 ? '<div class="pl-arrow" aria-hidden="true">&rsaquo;</div>' : "";
+      return '<div class="pl-stage" style="background:' + bg + ";color:" + col + '" title="' +
+          esc(r.phase) + (has ? " - " + r.avg.toFixed(1) + "/3" : " - not assessed") + '">' +
+          '<div class="pl-name">' + esc(shortPhase(r.phase)) + "</div>" +
+          '<div class="pl-val">' + (has ? r.avg.toFixed(1) : "&ndash;") + "</div>" +
+        "</div>" + arrow;
+    }).join("");
+    return (
+      '<div class="section-title">Maturity across the pipeline</div>' +
+      '<div class="pipeline card">' +
+        '<div class="pl-row">' + stages + "</div>" +
+        '<div class="pl-cap">Stages run left to right, from the start of the lifecycle through to operations. Darker means more mature.</div>' +
+      "</div>"
+    );
+  }
+
+  /* ---------- SVG charts (dependency-free) ---------- */
+  function donut(frac, label, sub) {
+    var r = 54, c = 2 * Math.PI * r;
+    frac = Math.max(0, Math.min(1, frac || 0));
+    var off = c * (1 - frac);
+    return (
+      '<svg viewBox="0 0 140 140" class="donut" role="img" aria-label="Overall maturity ' + esc(label) + '">' +
+        '<circle class="d-track" cx="70" cy="70" r="' + r + '"/>' +
+        '<circle class="d-val" cx="70" cy="70" r="' + r + '" stroke-dasharray="' + c.toFixed(2) +
+          '" stroke-dashoffset="' + off.toFixed(2) + '" transform="rotate(-90 70 70)"/>' +
+        '<text class="d-num" x="70" y="72" text-anchor="middle">' + esc(label) + "</text>" +
+        '<text class="d-sub" x="70" y="90" text-anchor="middle">' + esc(sub) + "</text>" +
+      "</svg>"
+    );
+  }
+
+  function radarChart(rows) {
+    var N = rows.length, cx = 200, cy = 162, R = 112;
+    if (!N) return "";
+    function pt(i, rad) {
+      var ang = (-90 + i * 360 / N) * Math.PI / 180;
+      return [cx + rad * Math.cos(ang), cy + rad * Math.sin(ang)];
+    }
+    function poly(rad, cls, extra) {
+      var pts = [];
+      for (var i = 0; i < N; i++) { var p = pt(i, rad(i)); pts.push(p[0].toFixed(1) + "," + p[1].toFixed(1)); }
+      return '<polygon class="' + cls + '" points="' + pts.join(" ") + '"' + (extra || "") + "/>";
+    }
+    var rings = [1, 2, 3].map(function (rv) { return poly(function () { return (rv / 3) * R; }, "ring"); }).join("");
+    var axes = "", labels = "", dots = "";
+    for (var i = 0; i < N; i++) {
+      var e = pt(i, R);
+      axes += '<line class="axis" x1="' + cx + '" y1="' + cy + '" x2="' + e[0].toFixed(1) + '" y2="' + e[1].toFixed(1) + '"/>';
+      var lp = pt(i, R + 20);
+      var anchor = Math.abs(lp[0] - cx) < 12 ? "middle" : (lp[0] > cx ? "start" : "end");
+      labels += '<text class="r-label" x="' + lp[0].toFixed(1) + '" y="' + (lp[1] + 4).toFixed(1) +
+        '" text-anchor="' + anchor + '">' + esc(shortPhase(rows[i].phase)) + "</text>";
+      var v = rows[i].avg == null ? 0 : rows[i].avg;
+      var dp = pt(i, (v / 3) * R);
+      dots += '<circle class="r-dot" cx="' + dp[0].toFixed(1) + '" cy="' + dp[1].toFixed(1) + '" r="2.6"/>';
+    }
+    var data = poly(function (i) { var v = rows[i].avg == null ? 0 : rows[i].avg; return (v / 3) * R; }, "r-data");
+    return '<svg viewBox="0 0 400 330" class="radar" role="img" aria-label="Maturity by phase">' +
+      rings + axes + data + dots + labels + "</svg>";
+  }
+
+  /* ---------- screenshot evidence (IndexedDB for image data, metadata in state) ---------- */
+  var DB_NAME = "dsovs-figures", STORE = "img";
+  function idb() {
+    return new Promise(function (res, rej) {
+      if (!("indexedDB" in window)) { rej(new Error("no indexedDB")); return; }
+      var r = indexedDB.open(DB_NAME, 1);
+      r.onupgradeneeded = function () { r.result.createObjectStore(STORE); };
+      r.onsuccess = function () { res(r.result); };
+      r.onerror = function () { rej(r.error); };
+    });
+  }
+  function idbPut(id, val) {
+    return idb().then(function (db) { return new Promise(function (res, rej) {
+      var t = db.transaction(STORE, "readwrite"); t.objectStore(STORE).put(val, id);
+      t.oncomplete = function () { res(); }; t.onerror = function () { rej(t.error); };
+    }); });
+  }
+  function idbGet(id) {
+    return idb().then(function (db) { return new Promise(function (res, rej) {
+      var t = db.transaction(STORE, "readonly"); var rq = t.objectStore(STORE).get(id);
+      rq.onsuccess = function () { res(rq.result || null); }; rq.onerror = function () { rej(rq.error); };
+    }); }).catch(function () { return null; });
+  }
+  function idbDel(id) {
+    return idb().then(function (db) { return new Promise(function (res) {
+      var t = db.transaction(STORE, "readwrite"); t.objectStore(STORE).delete(id);
+      t.oncomplete = function () { res(); };
+    }); }).catch(function () {});
+  }
+  function idbClear() {
+    return idb().then(function (db) { return new Promise(function (res) {
+      var t = db.transaction(STORE, "readwrite"); t.objectStore(STORE).clear();
+      t.oncomplete = function () { res(); };
+    }); }).catch(function () {});
+  }
+  function figId() {
+    try { if (window.crypto && crypto.randomUUID) return crypto.randomUUID(); } catch (e) {}
+    return "f" + Date.now() + "-" + Math.floor(Math.random() * 1e6);
+  }
+  function readAndResize(file, maxSide) {
+    return new Promise(function (res, rej) {
+      var fr = new FileReader();
+      fr.onload = function () {
+        var img = new Image();
+        img.onload = function () {
+          var scale = Math.min(1, maxSide / Math.max(img.width, img.height));
+          var cw = Math.max(1, Math.round(img.width * scale));
+          var ch = Math.max(1, Math.round(img.height * scale));
+          var cv = document.createElement("canvas");
+          cv.width = cw; cv.height = ch;
+          cv.getContext("2d").drawImage(img, 0, 0, cw, ch);
+          var keepPng = file.type === "image/png" && cw * ch < 600000;
+          res(cv.toDataURL(keepPng ? "image/png" : "image/jpeg", 0.92));
+        };
+        img.onerror = rej; img.src = fr.result;
+      };
+      fr.onerror = rej; fr.readAsDataURL(file);
+    });
+  }
+  function addFigures(id, files) {
+    var imgs = (files || []).filter(function (f) { return /^image\//.test(f.type); });
+    if (!imgs.length) return;
+    var a = answer(id); a.figures = a.figures || [];
+    Promise.all(imgs.map(function (f) {
+      return readAndResize(f, 1600).then(function (durl) {
+        var fid = figId();
+        return idbPut(fid, durl).then(function () {
+          a.figures.push({ id: fid, caption: "", name: f.name });
+        });
+      }).catch(function () {});
+    })).then(function () { save(); renderFigures(id); });
+  }
+  function figuresBlock(c) {
+    var figs = (answer(c.id).figures) || [];
+    var list = figs.length ? figs.map(function (f) {
+      return '<div class="fig">' +
+        '<img class="fig-thumb" data-fig-id="' + esc(f.id) + '" alt="">' +
+        '<div class="fig-meta">' +
+          '<input class="fig-cap" type="text" data-act="figcap" data-id="' + c.id + '" data-fig="' + esc(f.id) +
+            '" placeholder="Describe what this screenshot shows…" value="' + esc(f.caption || "") + '">' +
+          '<button class="fig-del" data-act="figdel" data-id="' + c.id + '" data-fig="' + esc(f.id) + '">Remove</button>' +
+        "</div></div>";
+    }).join("") : '<p class="fig-empty">Drag screenshots here, or use Add screenshot.</p>';
+    return (
+      '<div class="fig-head"><span class="evidence-title">Evidence screenshots</span>' +
+        '<label class="btn-mini">Add screenshot<input type="file" accept="image/*" multiple data-act="figfile" data-id="' + c.id + '" hidden></label>' +
+      "</div>" +
+      '<div class="fig-list">' + list + "</div>"
+    );
+  }
+  function loadFigureImages(root) {
+    if (!root) return;
+    root.querySelectorAll("img.fig-thumb[data-fig-id]").forEach(function (img) {
+      if (img.getAttribute("data-loaded")) return;
+      img.setAttribute("data-loaded", "1");
+      idbGet(img.getAttribute("data-fig-id")).then(function (d) { if (d) img.src = d; });
+    });
+  }
+  function renderFigures(id) {
+    var c = DATA.controls.find(function (x) { return x.id === id; });
+    var host = document.querySelector('[data-figs="' + id + '"]');
+    if (c && host) { host.innerHTML = figuresBlock(c); loadFigureImages(host); }
+  }
 
   /* ---------- setup fields ---------- */
   var els = {
@@ -78,9 +288,31 @@
 
   function renderNav() {
     var groups = byPhase();
-    document.getElementById("phase-nav").innerHTML = DATA.phases.map(function (p) {
-      return '<a href="#' + phaseId(p) + '">' + esc(p) + '<span class="n">' + groups[p].length + "</span></a>";
+    var items = DATA.phases.map(function (p) { return { p: p, id: phaseId(p), n: groups[p].length }; });
+    document.getElementById("phase-nav").innerHTML = items.map(function (it) {
+      return '<a href="#' + it.id + '" data-target="' + it.id + '">' + esc(it.p) + '<span class="n">' + it.n + "</span></a>";
     }).join("");
+    var rail = document.getElementById("rail");
+    if (rail) {
+      rail.innerHTML = '<div class="rail-title">Phases</div><ol>' + items.map(function (it) {
+        return '<li><a href="#' + it.id + '" data-target="' + it.id + '">' +
+          '<span class="rl">' + esc(it.p) + '</span><span class="c">' + it.n + "</span></a></li>";
+      }).join("") + "</ol>";
+    }
+  }
+
+  function setActive(id) {
+    document.querySelectorAll("[data-target]").forEach(function (a) {
+      a.classList.toggle("active", a.getAttribute("data-target") === id);
+    });
+  }
+  function setupSpy() {
+    var sections = Array.prototype.slice.call(document.querySelectorAll(".phase"));
+    if (!sections.length || !("IntersectionObserver" in window)) return;
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) { if (en.isIntersecting) setActive(en.target.id); });
+    }, { rootMargin: "-140px 0px -65% 0px", threshold: 0 });
+    sections.forEach(function (s) { obs.observe(s); });
   }
 
   function levelSeg(c) {
@@ -110,7 +342,7 @@
       : "";
     return (
       '<div class="level-detail">' +
-        '<p class="lt">Level ' + a.level + " &mdash; " + esc(lvl.title) + "</p>" +
+        '<p class="lt">Level ' + a.level + " - " + esc(lvl.title) + "</p>" +
         '<p class="ld">' + esc(lvl.description) + "</p>" +
         evBlock +
         '<div class="notes"><label>Notes</label>' +
@@ -132,13 +364,14 @@
         "</div>" +
         '<p class="control-summary">' + esc(firstPara(c.summary)) + "</p>" +
         '<details class="disclose"><summary></summary><div class="body">' +
-          paras(c.summary) +
-          '<a class="doc-link" href="' + esc(c.doc_url) + '" target="_blank" rel="noopener">Read the full control &rarr;</a>' +
+          restParas(c.summary) +
+          '<a class="doc-link" href="control.html?code=' + encodeURIComponent(c.code) + '" target="_blank" rel="noopener">Read the full control &rarr;</a>' +
         "</div></details>" +
         '<div class="levels" data-levels="' + c.id + '">' +
           levelSeg(c) +
           levelDetail(c) +
         "</div>" +
+        '<div class="figures" data-figs="' + c.id + '">' + figuresBlock(c) + "</div>" +
       "</div>"
     );
   }
@@ -171,7 +404,8 @@
   }
 
   /* ---------- events (delegated) ---------- */
-  document.getElementById("controls").addEventListener("click", function (e) {
+  var controlsEl = document.getElementById("controls");
+  controlsEl.addEventListener("click", function (e) {
     var btn = e.target.closest('[data-act="level"]');
     if (btn) {
       var id = btn.getAttribute("data-id");
@@ -180,20 +414,50 @@
       save();
       refreshLevels(id);
       updateProgress();
+      return;
+    }
+    var fd = e.target.closest('[data-act="figdel"]');
+    if (fd) {
+      var cid = fd.getAttribute("data-id"), fid = fd.getAttribute("data-fig");
+      var a = answer(cid);
+      a.figures = (a.figures || []).filter(function (x) { return x.id !== fid; });
+      idbDel(fid); save(); renderFigures(cid);
     }
   });
-  document.getElementById("controls").addEventListener("change", function (e) {
+  controlsEl.addEventListener("change", function (e) {
     var ev = e.target.closest('[data-act="ev"]');
     if (ev) {
       var a = answer(ev.getAttribute("data-id"));
       a.evidence = a.evidence || {};
       a.evidence[ev.getAttribute("data-key")] = ev.checked;
       save();
+      return;
+    }
+    var ff = e.target.closest('[data-act="figfile"]');
+    if (ff) {
+      addFigures(ff.getAttribute("data-id"), Array.prototype.slice.call(ff.files || []));
+      ff.value = "";
     }
   });
-  document.getElementById("controls").addEventListener("input", function (e) {
+  controlsEl.addEventListener("input", function (e) {
     var nt = e.target.closest('[data-act="notes"]');
-    if (nt) { answer(nt.getAttribute("data-id")).notes = nt.value; save(); }
+    if (nt) { answer(nt.getAttribute("data-id")).notes = nt.value; save(); return; }
+    var fc = e.target.closest('[data-act="figcap"]');
+    if (fc) {
+      var fid = fc.getAttribute("data-fig");
+      (answer(fc.getAttribute("data-id")).figures || []).forEach(function (x) { if (x.id === fid) x.caption = fc.value; });
+      save();
+    }
+  });
+  controlsEl.addEventListener("dragover", function (e) {
+    if (e.target.closest(".figures")) { e.preventDefault(); }
+  });
+  controlsEl.addEventListener("drop", function (e) {
+    var fz = e.target.closest(".figures");
+    if (fz) {
+      e.preventDefault();
+      addFigures(fz.getAttribute("data-figs"), Array.prototype.slice.call(e.dataTransfer.files || []));
+    }
   });
 
   /* ---------- progress ---------- */
@@ -242,12 +506,70 @@
     var strengths = assessed.filter(function (c) { return state.answers[c.id].level >= 3; }).length;
     var notAssessed = controls.length - assessed.length;
 
+    /* number screenshot evidence in control order: Figure 1..N */
+    var figNum = 0, figuresOrder = [], figByControl = {};
+    controls.forEach(function (c) {
+      var a = state.answers[c.id];
+      if (!a || !a.figures || !a.figures.length) return;
+      a.figures.forEach(function (f) {
+        figNum++;
+        figuresOrder.push({ num: figNum, controlId: c.id, code: c.code, title: c.title, docUrl: c.doc_url, figId: f.id, caption: f.caption || "" });
+        (figByControl[c.id] = figByControl[c.id] || []).push(figNum);
+      });
+    });
+
+    /* prose executive summary */
+    var ranked = phaseRows.filter(function (r) { return r.avg != null; }).slice()
+      .sort(function (a, b) { return b.avg - a.avg; });
+    var best = ranked[0], worst = ranked[ranked.length - 1];
+    var introBody;
+    if (!assessed.length) {
+      introBody = "<p>" + (state.meta.org ? esc(state.meta.org) : "This project") +
+        " has not been assessed yet. Choose a maturity level for each control to build a maturity profile, a prioritised roadmap and an evidence pack you can export or print.</p>";
+    } else {
+      var who = state.meta.org ? esc(state.meta.org) : "This project";
+      var when = state.meta.date ? " on " + esc(state.meta.date) : "";
+      var lowGaps = gaps.filter(function (c) { return state.answers[c.id].level <= 1; }).length;
+
+      var p1 = who + " was assessed against the OWASP DevSecOps Verification Standard" + when + ". " +
+        assessed.length + " of " + controls.length + " controls were rated, giving an overall maturity of " +
+        avg.toFixed(1) + " out of 3 - " + (/^[ae]/.test(maturityWord(avg)) ? "an " : "a ") +
+        maturityWord(avg) + " posture - against a target of Level " + target + ".";
+
+      var p2 = meetingTarget + " control" + (meetingTarget === 1 ? "" : "s") + " already meet" +
+        (meetingTarget === 1 ? "s" : "") + " the target and " + gaps.length + " fall" + (gaps.length === 1 ? "s" : "") + " short.";
+      if (best && worst && best !== worst) {
+        p2 += " Maturity is strongest in " + esc(best.phase) + " (" + best.avg.toFixed(1) + ") and weakest in " +
+          esc(worst.phase) + " (" + worst.avg.toFixed(1) + "), so " + esc(worst.phase) +
+          " is where further investment will reduce risk most.";
+      } else if (best) {
+        p2 += " Assessed work so far centres on " + esc(best.phase) + " (" + best.avg.toFixed(1) + ").";
+      }
+
+      var p3;
+      if (gaps.length) {
+        p3 = "The roadmap below lists each gap in priority order" +
+          (lowGaps ? ", starting with the " + lowGaps + " control" + (lowGaps > 1 ? "s" : "") +
+            " sitting at Level 0 or 1 that carry the most risk and offer the fastest improvement" : "") +
+          ". For each one it states the specific next step and the evidence required to verify it.";
+      } else {
+        p3 = "Every assessed control meets the target, so the priority now is to sustain these practices and keep the supporting evidence current.";
+      }
+
+      var p4 = figNum ? "<p>" + figNum + " screenshot" + (figNum > 1 ? "s are" : " is") +
+        " attached as supporting evidence (Figure" + (figNum > 1 ? "s 1-" + figNum : " 1") + ").</p>" : "";
+      introBody = "<p>" + p1 + "</p><p>" + p2 + "</p><p>" + p3 + "</p>" + p4;
+    }
+    var introHtml = '<div class="report-intro">' + introBody + "</div>";
+
     var meta = state.meta;
+    var reportId = currentReportId();
     var metaLine =
       (meta.org ? "<span>" + esc(meta.org) + "</span>" : "") +
       (meta.assessor ? "<span>" + esc(meta.assessor) + "</span>" : "") +
       (meta.date ? "<span>" + esc(meta.date) + "</span>" : "") +
-      "<span>Target level " + target + "</span>";
+      "<span>Target level " + target + "</span>" +
+      '<span class="rid">Report ' + reportId + "</span>";
 
     var stats =
       '<div class="stat-grid">' +
@@ -259,17 +581,15 @@
           '</div><div class="lab">Meeting target (L' + target + "+)</div></div>" +
       "</div>";
 
-    var bars =
-      '<div class="section-title">Maturity by phase</div>' +
-      '<div class="bars card">' +
-      phaseRows.map(function (r) {
-        var w = r.avg == null ? 0 : (r.avg / 3) * 100;
-        var num = r.avg == null ? "&ndash;" : r.avg.toFixed(1);
-        return '<div class="bar-row"><div class="name">' + esc(r.phase) +
-          '</div><div class="bar-track"><div class="bar-val" style="width:' + w + '%"></div></div>' +
-          '<div class="bar-num">' + num + "</div></div>";
-      }).join("") +
+    var charts =
+      '<div class="section-title">Overview</div>' +
+      '<div class="charts card">' +
+        '<div class="donut-wrap">' + donut(avg / 3, avg.toFixed(1), "of 3") +
+          '<div class="donut-cap">Overall maturity</div></div>' +
+        '<div class="radar-wrap">' + radarChart(phaseRows) + "</div>" +
       "</div>";
+
+    var pipeline = pipelineFlow(phaseRows);
 
     var gapHtml;
     if (!assessed.length) {
@@ -291,12 +611,18 @@
             "</div>";
         }
         var note = a.notes ? '<div class="gap-note"><b>Note:</b> ' + esc(a.notes) + "</div>" : "";
+        var figs = figByControl[c.id];
+        var figRef = figs ? '<div class="gap-figref">Evidence: ' +
+          figs.map(function (n) { return "Figure " + n; }).join(", ") + "</div>" : "";
+        var why = '<div class="gap-why">' + esc(firstSentence(c.summary)) + "</div>";
         return (
           '<div class="gap card">' +
-            '<div class="gap-top"><div><div class="g-id">' + esc(c.code) + "</div>" +
+            '<div class="gap-top"><div>' +
+              '<a class="g-id" href="control.html?code=' + encodeURIComponent(c.code) + '" target="_blank" rel="noopener" title="Open ' +
+                esc(c.code) + '">' + esc(c.code) + "</a>" +
               '<div class="g-title">' + esc(c.title) + "</div></div>" +
               '<div class="gap-move">Now <b>L' + a.level + "</b> &rarr; target <b>L" + target + "</b></div></div>" +
-            nextBlock + note +
+            why + nextBlock + note + figRef +
           "</div>"
         );
       }).join("");
@@ -305,12 +631,16 @@
     var summaryNote =
       '<div class="section-title">Priority gaps &middot; ' + gaps.length + " below target" +
       (notAssessed ? " &middot; " + notAssessed + " not yet assessed" : "") +
-      (strengths ? " &middot; " + strengths + " at Level 3" : "") + "</div>";
+      (strengths ? " &middot; " + strengths + " at Level 3" : "") +
+      (figNum ? " &middot; " + figNum + " screenshot" + (figNum > 1 ? "s" : "") : "") + "</div>" +
+      (gaps.length ? '<p class="section-lead">Ordered by lowest maturity first, so the largest risks appear at the top. Each entry is the next concrete step toward the target, with the evidence an assessor would expect to see.</p>' : "");
 
     document.getElementById("report").innerHTML =
       '<div class="report-head"><h1>DevSecOps Maturity Report</h1>' +
         '<div class="report-meta">' + metaLine + "</div></div>" +
-      stats + bars + summaryNote + gapHtml +
+      introHtml +
+      stats + charts + pipeline + summaryNote + gapHtml +
+      '<div id="evidence-slot"></div>' +
       '<div class="report-actions">' +
         '<button class="btn ghost" id="back">&larr; Back to assessment</button>' +
         '<button class="btn ghost" id="export">Export JSON</button>' +
@@ -318,24 +648,73 @@
       "</div>";
 
     document.getElementById("back").addEventListener("click", function () { switchView("assess"); });
-    document.getElementById("print").addEventListener("click", function () { window.print(); });
+    document.getElementById("print").addEventListener("click", function () {
+      var slug = (state.meta.org || "report").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "") || "report";
+      var prev = document.title;
+      document.title = "DSOVS-" + slug + "-" + (state.meta.date || today()) + "-" + reportId;
+      function restore() { document.title = prev; window.removeEventListener("afterprint", restore); }
+      window.addEventListener("afterprint", restore);
+      window.print();
+    });
     document.getElementById("export").addEventListener("click", exportJson);
+
+    loadEvidence(figuresOrder);
+  }
+
+  function loadEvidence(items) {
+    var slot = document.getElementById("evidence-slot");
+    if (!slot) return;
+    if (!items || !items.length) { slot.innerHTML = ""; return; }
+    Promise.all(items.map(function (it) {
+      return idbGet(it.figId).then(function (d) {
+        return { num: it.num, controlId: it.controlId, code: it.code, title: it.title, docUrl: it.docUrl, caption: it.caption, data: d };
+      });
+    })).then(function (loaded) {
+      var order = [], groups = {};
+      loaded.forEach(function (it) {
+        if (!groups[it.controlId]) { groups[it.controlId] = { code: it.code, title: it.title, docUrl: it.docUrl, items: [] }; order.push(it.controlId); }
+        groups[it.controlId].items.push(it);
+      });
+      var html = '<div class="section-title">Evidence</div>';
+      order.forEach(function (cid) {
+        var g = groups[cid];
+        html += '<div class="evidence-block card"><div class="ev-ctl">' +
+          '<a class="g-id" href="control.html?code=' + encodeURIComponent(g.code) + '" target="_blank" rel="noopener" title="Open ' +
+            esc(g.code) + '">' + esc(g.code) + "</a> - " + esc(g.title) + "</div>";
+        g.items.forEach(function (it) {
+          html += '<figure class="figure">' +
+            (it.data ? '<img src="' + it.data + '" alt="Figure ' + it.num + '">' : '<div class="fig-missing">Image unavailable</div>') +
+            '<figcaption><b>Figure ' + it.num + ".</b> " +
+              (it.caption ? esc(it.caption) : '<span class="muted">No description provided</span>') +
+            "</figcaption></figure>";
+        });
+        html += "</div>";
+      });
+      slot.innerHTML = html;
+    });
   }
 
   function exportJson() {
+    var id = currentReportId();
     var payload = {
       standard: DATA.standard,
       version: DATA.version,
+      report_id: id,
       exported: new Date().toISOString(),
       meta: state.meta,
       results: DATA.controls.map(function (c) {
         var a = state.answers[c.id] || {};
-        return { id: c.id, code: c.code, title: c.title, phase: c.phase, level: a.level == null ? null : a.level, notes: a.notes || "" };
+        return {
+          id: c.id, code: c.code, title: c.title, phase: c.phase,
+          level: a.level == null ? null : a.level, notes: a.notes || "",
+          screenshots: (a.figures || []).map(function (f) { return f.caption || f.name || "screenshot"; }),
+        };
       }),
     };
     var blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     var url = URL.createObjectURL(blob);
-    var name = "dsovs-assessment-" + (state.meta.org || "report").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") + ".json";
+    var orgslug = (state.meta.org || "report").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "report";
+    var name = "dsovs-assessment-" + orgslug + "-" + (state.meta.date || today()) + "-" + id + ".json";
     var a = document.createElement("a");
     a.href = url; a.download = name; a.click();
     setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
@@ -359,17 +738,24 @@
   });
   document.getElementById("goto-report").addEventListener("click", function () { switchView("report"); });
 
-  document.getElementById("reset").addEventListener("click", function () {
-    if (!confirm("Clear every answer and start over? This cannot be undone.")) return;
+  function resetAll() {
+    if (!confirm("Clear every answer, note and screenshot stored in this browser? This cannot be undone.")) return;
     try { localStorage.removeItem(STORE_KEY); } catch (e) {}
+    idbClear();
     state = load();
     els.org.value = ""; els.assessor.value = ""; els.date.value = state.meta.date; els.target.value = "2";
-    renderControls(); updateProgress();
+    switchView("assess");
+    renderControls(); loadFigureImages(controlsEl); updateProgress();
     window.scrollTo({ top: 0, behavior: "smooth" });
-  });
+  }
+  document.getElementById("reset").addEventListener("click", resetAll);
+  var topresetBtn = document.getElementById("topreset");
+  if (topresetBtn) topresetBtn.addEventListener("click", resetAll);
 
   /* ---------- init ---------- */
   renderNav();
   renderControls();
+  loadFigureImages(controlsEl);
+  setupSpy();
   updateProgress();
 })();

--- a/assessment/assess.html
+++ b/assessment/assess.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DSOVS Self-Assessment</title>
+  <meta name="description" content="Self-assess your software development lifecycle against the OWASP DevSecOps Verification Standard. Everything stays in your browser." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="index.html" title="Back to the DSOVS home">
+        <img class="brand-logo" src="https://upload.wikimedia.org/wikipedia/commons/e/ef/OWASP_black_logo.svg" alt="OWASP" width="86" height="28" />
+        <span class="brand-divider" aria-hidden="true"></span>
+        <span class="brand-mark">DSOVS</span>
+        <span class="brand-sub">DevSecOps Verification Standard</span>
+      </a>
+      <div class="top-right">
+        <button class="topreset" id="topreset" type="button" title="Clear all saved answers, notes and screenshots stored in this browser">Reset</button>
+        <nav class="view-switch" aria-label="Views">
+          <button class="seg" data-view="assess" aria-pressed="true">Assessment</button>
+          <button class="seg" data-view="report" aria-pressed="false">Report</button>
+        </nav>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <!-- ASSESSMENT VIEW -->
+    <section id="view-assess">
+      <aside class="rail" id="rail" aria-label="Jump to phase"></aside>
+      <div class="hero">
+        <h1>Self-Assessment</h1>
+        <p class="lede">Rate each control against the four DSOVS maturity levels, capture evidence and notes, then generate a report. Your answers never leave this browser - they are saved locally on this device.</p>
+      </div>
+
+      <div class="setup card">
+        <div class="field">
+          <label for="org">Organisation / project</label>
+          <input id="org" type="text" placeholder="e.g. Acme Payments" autocomplete="off" />
+        </div>
+        <div class="field">
+          <label for="assessor">Assessor</label>
+          <input id="assessor" type="text" placeholder="Your name" autocomplete="off" />
+        </div>
+        <div class="field">
+          <label for="date">Date</label>
+          <input id="date" type="date" />
+        </div>
+        <div class="field">
+          <label for="target">Target level</label>
+          <select id="target">
+            <option value="1">Level 1</option>
+            <option value="2" selected>Level 2</option>
+            <option value="3">Level 3</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="progress-bar card" id="progress">
+        <div class="progress-meta">
+          <span id="progress-count">0 of 0 assessed</span>
+          <span id="progress-pct" class="muted">0%</span>
+        </div>
+        <div class="track"><div class="fill" id="progress-fill" style="width:0%"></div></div>
+      </div>
+
+      <nav class="phase-nav" id="phase-nav" aria-label="Jump to phase"></nav>
+
+      <div id="controls"></div>
+
+      <div class="footer-actions">
+        <button class="btn ghost" id="reset">Reset all answers</button>
+        <button class="btn primary" id="goto-report">Generate report &rarr;</button>
+      </div>
+    </section>
+
+    <!-- REPORT VIEW -->
+    <section id="view-report" hidden>
+      <div id="report"></div>
+    </section>
+  </main>
+
+  <footer class="sitefoot">
+    <span>OWASP DevSecOps Verification Standard</span>
+    <a href="https://github.com/OWASP/www-project-devsecops-verification-standard" target="_blank" rel="noopener">Project on GitHub</a>
+  </footer>
+
+  <script src="data.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/assessment/control.css
+++ b/assessment/control.css
@@ -1,0 +1,92 @@
+/* Control document page. Reuses tokens, .topbar, .card, .btn, .sitefoot, .top-actions from styles/home. */
+
+.top-actions { display: flex; align-items: center; gap: 18px; }
+.toplink { font-size: 14px; color: var(--text-2); text-decoration: none; }
+.toplink:hover { color: var(--text); }
+.btn.sm { padding: 8px 16px; font-size: 14px; }
+a.brand { text-decoration: none; }
+
+.dwrap { max-width: 760px; margin: 0 auto; padding: 32px 24px 72px; }
+.back { display: inline-block; font-size: 14px; color: var(--text-2); text-decoration: none; margin-bottom: 24px; }
+.back:hover { color: var(--text); }
+.notfound { color: var(--text-2); }
+
+/* Header */
+.dhead { margin-bottom: 8px; }
+.deyebrow { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
+.dphase { font-size: 13px; font-weight: 500; color: var(--text-2); }
+.dcode { font-family: var(--mono); font-size: 12px; color: var(--text-3); }
+.dbadge { font-size: 11px; font-weight: 500; color: var(--text-2); background: var(--bg-subtle); border-radius: 980px; padding: 3px 9px; text-transform: capitalize; }
+.dhead h1 { font-size: 38px; line-height: 1.1; letter-spacing: -0.02em; font-weight: 600; margin: 0 0 18px; }
+.dsummary p { font-size: 18px; line-height: 1.55; color: var(--text-2); margin: 0 0 14px; }
+
+/* Sections */
+.dsection { margin-top: 48px; }
+.dsection > h2 { font-size: 13px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.05em; margin: 0 0 18px; }
+
+/* Levels */
+.levels-doc { display: flex; flex-direction: column; gap: 14px; }
+.ldoc { border: 1px solid var(--border-subtle); border-radius: var(--radius); padding: 22px; background: var(--card); }
+.ldoc-head { display: flex; align-items: center; gap: 14px; margin-bottom: 12px; }
+.ldoc-n {
+  flex: none; width: 34px; height: 34px; border-radius: 9px; background: var(--text); color: #fff;
+  display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 16px;
+}
+.ldoc-tag { font-size: 12px; font-weight: 500; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.04em; }
+.ldoc-head h3 { font-size: 16px; font-weight: 600; margin: 2px 0 0; letter-spacing: -0.01em; }
+.ldoc-body p { font-size: 15px; line-height: 1.55; color: var(--text-2); margin: 0 0 12px; }
+.ldoc-body p:last-child { margin-bottom: 0; }
+
+.evidence { margin-top: 14px; border-top: 1px solid var(--border-subtle); padding-top: 14px; }
+.evidence-h { font-size: 12px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 8px; }
+.evidence ul { margin: 0; padding-left: 18px; }
+.evidence li { font-size: 14px; line-height: 1.5; color: var(--text-2); margin-bottom: 5px; }
+
+/* Mermaid */
+pre.mermaid { background: var(--bg-subtle); border-radius: 10px; padding: 18px; margin: 6px 0 14px; text-align: center; overflow-x: auto; line-height: 1.2; }
+
+/* Tools */
+.disclaimer { font-size: 13px; color: var(--text-3); line-height: 1.5; margin: -6px 0 18px; max-width: 64ch; }
+.tool { padding: 22px; margin-bottom: 14px; }
+.tool-head h3 { font-size: 17px; font-weight: 600; margin: 0; }
+.tool-head a { color: var(--text); text-decoration: none; }
+.tool-head a:hover { text-decoration: underline; }
+.tool-desc p { font-size: 14.5px; line-height: 1.55; color: var(--text-2); margin: 8px 0 0; }
+.snippet { margin-top: 16px; }
+.snippet-h { font-size: 12px; font-weight: 600; color: var(--text-2); margin-bottom: 8px; }
+.snippet-h a { color: var(--text-2); text-decoration: none; }
+.snippet-h a:hover { color: var(--text); text-decoration: underline; }
+pre { background: #1d1d1f; color: #f5f5f7; border-radius: 10px; padding: 16px 18px; overflow-x: auto; margin: 0; }
+pre code { font-family: var(--mono); font-size: 12.5px; line-height: 1.55; white-space: pre; }
+
+/* Mappings */
+.maps { display: flex; flex-direction: column; gap: 0; border: 1px solid var(--border-subtle); border-radius: var(--radius); overflow: hidden; }
+.map-row { display: grid; grid-template-columns: 130px 1fr; gap: 14px; padding: 14px 18px; border-top: 1px solid var(--border-subtle); }
+.map-row:first-child { border-top: none; }
+.map-k { font-size: 13px; font-weight: 600; color: var(--text); }
+.map-v { display: flex; flex-wrap: wrap; gap: 6px; }
+.chip { font-size: 12.5px; color: var(--text-2); background: var(--bg-subtle); border-radius: 7px; padding: 4px 9px; }
+
+/* Reading / credits */
+.reading { list-style: none; margin: 0; padding: 0; }
+.reading li { border-top: 1px solid var(--border-subtle); }
+.reading li:first-child { border-top: none; }
+.reading a { display: block; padding: 11px 0; font-size: 14.5px; color: var(--text-2); text-decoration: none; line-height: 1.45; }
+.reading a:hover { color: var(--text); }
+
+/* Footer CTA + pager */
+.dfoot { display: flex; align-items: center; gap: 18px; margin-top: 48px; flex-wrap: wrap; }
+.dsource { font-size: 13px; color: var(--text-3); text-decoration: none; }
+.dsource:hover { color: var(--text-2); text-decoration: underline; }
+
+.dpager { display: flex; justify-content: space-between; gap: 14px; margin-top: 40px; border-top: 1px solid var(--border-subtle); padding-top: 24px; }
+.dpager a { display: flex; flex-direction: column; gap: 3px; font-size: 14px; font-weight: 500; color: var(--text); text-decoration: none; max-width: 48%; }
+.dpager a.next { text-align: right; margin-left: auto; }
+.dpager a span { font-size: 12px; font-weight: 400; color: var(--text-3); }
+.dpager a:hover { color: var(--text); }
+.dpager a:hover span { color: var(--text-2); }
+
+@media (max-width: 640px) {
+  .dhead h1 { font-size: 30px; }
+  .map-row { grid-template-columns: 1fr; gap: 6px; }
+}

--- a/assessment/control.html
+++ b/assessment/control.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DSOVS Control</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="control.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="index.html">
+        <img class="brand-logo" src="https://upload.wikimedia.org/wikipedia/commons/e/ef/OWASP_black_logo.svg" alt="OWASP" width="86" height="28" />
+        <span class="brand-divider" aria-hidden="true"></span>
+        <span class="brand-mark">DSOVS</span>
+        <span class="brand-sub">DevSecOps Verification Standard</span>
+      </a>
+      <nav class="top-actions" aria-label="Primary">
+        <a class="toplink" href="index.html#standard">The standard</a>
+        <a class="btn primary sm" href="assess.html">Self-Assessment</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="dwrap">
+    <a class="back" href="index.html#standard">&larr; The standard</a>
+    <article id="control"></article>
+  </main>
+
+  <footer class="sitefoot">
+    <span>OWASP DevSecOps Verification Standard</span>
+    <a href="https://github.com/OWASP/www-project-devsecops-verification-standard" target="_blank" rel="noopener">Project on GitHub</a>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script src="data.js"></script>
+  <script src="control.js"></script>
+</body>
+</html>

--- a/assessment/control.js
+++ b/assessment/control.js
@@ -1,0 +1,156 @@
+/* Renders a single DSOVS control in the site design, from the shared data (no drift). */
+(function () {
+  "use strict";
+  var DATA = window.DSOVS_DATA;
+  var root = document.getElementById("control");
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+  function paras(text) {
+    return String(text || "").split(/\n\s*\n/).map(function (p) {
+      return "<p>" + esc(p.trim()) + "</p>";
+    }).join("");
+  }
+  function param(name) {
+    var m = new RegExp("[?&]" + name + "=([^&]+)").exec(location.search);
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+
+  var LEVEL_LABELS = ["Initial", "Basic", "Managed", "Optimised"];
+  var PLATFORM = {
+    "github-actions": "GitHub Actions", "gitlab-ci": "GitLab CI",
+    "azure-devops": "Azure DevOps", "cli": "Command line", "config": "Configuration",
+  };
+  var MAP_LABELS = {
+    owasp_samm: "OWASP SAMM", owasp_asvs: "OWASP ASVS",
+    nist_ssdf: "NIST SSDF", iso_27001: "ISO 27001", other: "Other",
+  };
+
+  if (!DATA || !Array.isArray(DATA.controls)) {
+    root.innerHTML = '<p class="notfound">Could not load the standard data.</p>';
+    return;
+  }
+
+  var code = (param("code") || param("id") || "").toUpperCase().replace(/^DSOVS-/, "");
+  var control = DATA.controls.filter(function (c) { return c.code === code; })[0];
+  if (!control) {
+    root.innerHTML = '<p class="notfound">Control <code>' + esc(code || "?") +
+      '</code> was not found. <a href="index.html#standard">Back to the standard</a>.</p>';
+    return;
+  }
+
+  document.title = control.code + " " + control.title + " - DSOVS";
+
+  var html = "";
+
+  /* header */
+  html += '<header class="dhead">' +
+    '<div class="deyebrow"><span class="dphase">' + esc(control.phase) + "</span>" +
+      '<span class="dcode">' + esc(control.code) + "</span>" +
+      '<span class="dbadge">' + esc(control.type) + "</span></div>" +
+    "<h1>" + esc(control.title) + "</h1>" +
+    '<div class="dsummary">' + paras(control.summary) + "</div>" +
+  "</header>";
+
+  /* levels */
+  html += '<section class="dsection"><h2>Maturity levels</h2><div class="levels-doc">';
+  control.levels.forEach(function (lvl) {
+    html += '<div class="ldoc">' +
+      '<div class="ldoc-head"><span class="ldoc-n">' + lvl.level + "</span>" +
+        '<div><div class="ldoc-tag">Level ' + lvl.level + " &middot; " + esc(LEVEL_LABELS[lvl.level] || "") + "</div>" +
+        "<h3>" + esc(lvl.title) + "</h3></div></div>" +
+      '<div class="ldoc-body">' + paras(lvl.description);
+    if (lvl.diagram) {
+      html += '<pre class="mermaid">' + esc(lvl.diagram) + "</pre>";
+    }
+    if (lvl.evidence && lvl.evidence.length) {
+      html += '<div class="evidence"><div class="evidence-h">Verification evidence</div><ul>' +
+        lvl.evidence.map(function (e) { return "<li>" + esc(e) + "</li>"; }).join("") + "</ul></div>";
+    }
+    html += "</div></div>";
+  });
+  html += "</div></section>";
+
+  /* notable tools */
+  if (control.tools && control.tools.length) {
+    html += '<section class="dsection"><h2>Notable tools</h2>' +
+      '<p class="disclaimer">Apart from official OWASP Projects, these tools were chosen on the basis of their proven capabilities alone. There is no other relationship between the DSOVS project leaders and their creators or vendors.</p>';
+    control.tools.forEach(function (t) {
+      html += '<div class="tool card"><div class="tool-head"><h3>' +
+        '<a href="' + esc(t.url) + '" target="_blank" rel="noopener">' + esc(t.name) + "</a></h3></div>" +
+        '<div class="tool-desc">' + paras(t.description) + "</div>";
+      (t.integrations || []).forEach(function (ig) {
+        var label = ig.label || PLATFORM[ig.platform] || ig.platform;
+        var head = ig.link
+          ? '<a href="' + esc(ig.link) + '" target="_blank" rel="noopener">' + esc(label) + "</a>"
+          : esc(label);
+        html += '<div class="snippet"><div class="snippet-h">' + head + "</div>" +
+          "<pre><code>" + esc(ig.code) + "</code></pre></div>";
+      });
+      html += "</div>";
+    });
+    html += "</section>";
+  }
+
+  /* mappings */
+  if (control.mappings) {
+    var rows = Object.keys(control.mappings).filter(function (k) {
+      return control.mappings[k] && control.mappings[k].length;
+    });
+    if (rows.length) {
+      html += '<section class="dsection"><h2>Framework mappings</h2><div class="maps">';
+      rows.forEach(function (k) {
+        html += '<div class="map-row"><div class="map-k">' + esc(MAP_LABELS[k] || k) + "</div>" +
+          '<div class="map-v">' + control.mappings[k].map(function (v) {
+            return '<span class="chip">' + esc(v) + "</span>";
+          }).join("") + "</div></div>";
+      });
+      html += "</div></section>";
+    }
+  }
+
+  /* further reading */
+  if (control.further_reading && control.further_reading.length) {
+    html += '<section class="dsection"><h2>Further reading</h2><ul class="reading">' +
+      control.further_reading.map(function (r) {
+        return '<li><a href="' + esc(r.url) + '" target="_blank" rel="noopener">' +
+          esc(r.note || r.url) + "</a></li>";
+      }).join("") + "</ul></section>";
+  }
+
+  /* credits */
+  if (control.credits && control.credits.length) {
+    html += '<section class="dsection"><h2>Credits</h2><ul class="reading">' +
+      control.credits.map(function (c) {
+        return "<li>" + (c.url ? '<a href="' + esc(c.url) + '" target="_blank" rel="noopener">' + esc(c.name) + "</a>" : esc(c.name)) + "</li>";
+      }).join("") + "</ul></section>";
+  }
+
+  /* provenance + CTA */
+  html += '<div class="dfoot">' +
+    '<a class="btn primary" href="assess.html">Assess this in the self-assessment &rarr;</a>' +
+    '<a class="dsource" href="' + esc(control.doc_url) + '" target="_blank" rel="noopener">View source on GitHub</a>' +
+  "</div>";
+
+  root.innerHTML = html;
+
+  /* render mermaid diagrams if the library loaded */
+  if (window.mermaid) {
+    try {
+      window.mermaid.initialize({ startOnLoad: false, theme: "neutral", securityLevel: "strict" });
+      window.mermaid.run({ nodes: root.querySelectorAll("pre.mermaid") });
+    } catch (e) {}
+  }
+
+  /* prev / next nav within the standard */
+  var idx = DATA.controls.indexOf(control);
+  var prev = DATA.controls[idx - 1], next = DATA.controls[idx + 1];
+  var nav = document.createElement("nav");
+  nav.className = "dpager";
+  nav.innerHTML =
+    (prev ? '<a href="control.html?code=' + prev.code + '"><span>Previous</span>' + esc(prev.code) + " " + esc(prev.title) + "</a>" : "<span></span>") +
+    (next ? '<a class="next" href="control.html?code=' + next.code + '"><span>Next</span>' + esc(next.code) + " " + esc(next.title) + "</a>" : "<span></span>");
+  root.appendChild(nav);
+})();

--- a/assessment/home.css
+++ b/assessment/home.css
@@ -1,0 +1,90 @@
+/* Landing-page styles. Reuses tokens, .topbar, .card, .btn, .sitefoot from styles.css */
+
+a.brand { text-decoration: none; }
+
+.top-actions { display: flex; align-items: center; gap: 18px; }
+.toplink { font-size: 14px; color: var(--text-2); text-decoration: none; }
+.toplink:hover { color: var(--text); }
+.btn.sm { padding: 8px 16px; font-size: 14px; }
+
+.lwrap { max-width: 1040px; margin: 0 auto; padding: 24px 24px 64px; }
+
+/* Hero */
+.lhero { text-align: center; padding: 56px 0 60px; }
+.lpill {
+  display: inline-block; font-size: 12px; font-weight: 500; letter-spacing: 0.04em;
+  color: var(--text-2); background: var(--card); border: 1px solid var(--border-subtle);
+  border-radius: 980px; padding: 5px 13px; margin-bottom: 22px;
+}
+.lhero h1 { font-size: 54px; line-height: 1.04; letter-spacing: -0.03em; font-weight: 600; margin: 0 0 18px; }
+.lhero-sub { font-size: 20px; line-height: 1.5; color: var(--text-2); max-width: 660px; margin: 0 auto 30px; }
+.lhero-cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+.lhero-stat { margin-top: 26px; font-family: var(--mono); font-size: 13px; color: var(--text-3); }
+
+/* Use cases */
+.luse { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-bottom: 28px; }
+.lcard { padding: 26px; }
+.lico {
+  width: 44px; height: 44px; border-radius: 12px; margin-bottom: 16px;
+  background: var(--bg-subtle); display: flex; align-items: center; justify-content: center; color: var(--text);
+}
+.lico svg { width: 22px; height: 22px; }
+.lcard h3 { font-size: 18px; font-weight: 600; margin: 0 0 8px; letter-spacing: -0.01em; }
+.lcard p { font-size: 14.5px; line-height: 1.55; color: var(--text-2); margin: 0; }
+
+/* Self-assessment band */
+.lband {
+  display: grid; grid-template-columns: 1.4fr 1fr; gap: 28px; align-items: center;
+  padding: 40px; margin: 28px 0 64px; background: var(--text); border: none;
+}
+.lband-text h2 { font-size: 28px; font-weight: 600; letter-spacing: -0.02em; color: #fff; margin: 0 0 12px; }
+.lband-text p { font-size: 16px; line-height: 1.55; color: rgba(255,255,255,0.72); margin: 0 0 22px; max-width: 48ch; }
+.lband .btn.primary { background: #fff; color: var(--text); }
+.lband .btn.primary:hover { background: #f0f0f2; }
+.lband-levels { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+.llv {
+  background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); border-radius: 12px;
+  padding: 14px 16px; color: rgba(255,255,255,0.82); font-size: 13px; font-weight: 500;
+}
+.llv span { display: block; font-size: 26px; font-weight: 600; color: #fff; letter-spacing: -0.02em; margin-bottom: 2px; }
+
+/* Standard / table of contents */
+.lsec-head { margin-bottom: 22px; }
+.lsec-head h2 { font-size: 32px; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 10px; }
+.lsec-head p { font-size: 16px; line-height: 1.55; color: var(--text-2); max-width: 68ch; margin: 0; }
+
+.toc { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.tphase { padding: 22px; }
+.tphase-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+.tphase-head h3 { font-size: 17px; font-weight: 600; margin: 0; letter-spacing: -0.01em; }
+.tphase-head .c { font-family: var(--mono); font-size: 12px; color: var(--text-3); }
+.tchips { margin-top: 10px; }
+.tchip {
+  display: flex; gap: 12px; align-items: baseline; padding: 8px 0; text-decoration: none;
+  border-top: 1px solid var(--border-subtle); font-size: 14px; color: var(--text-2);
+}
+.tchip:first-child { border-top: none; }
+.tchip:hover { color: var(--text); }
+.tchip .cc { font-family: var(--mono); font-size: 11.5px; color: var(--text-3); flex: none; min-width: 62px; }
+.tchip:hover .cc { color: var(--text-2); }
+
+/* Get involved / connect */
+.linvolved { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 64px; }
+.linvolved h3 { font-size: 18px; font-weight: 600; margin: 0 0 8px; }
+.linvolved p { font-size: 14.5px; color: var(--text-2); margin: 0 0 16px; }
+.llist { list-style: none; margin: 0; padding: 0; }
+.llist li { border-top: 1px solid var(--border-subtle); }
+.llist li:first-child { border-top: none; }
+.llist a { display: flex; align-items: center; gap: 11px; padding: 11px 0; font-size: 14.5px; color: var(--text-2); text-decoration: none; }
+.llist a:hover { color: var(--text); }
+.li-ico { width: 17px; height: 17px; color: var(--text-3); flex: none; }
+.llist a:hover .li-ico { color: var(--text-2); }
+
+@media (max-width: 860px) {
+  .luse { grid-template-columns: 1fr; }
+  .lband { grid-template-columns: 1fr; padding: 30px; }
+  .lband-levels { grid-template-columns: repeat(4, 1fr); }
+  .toc { grid-template-columns: 1fr; }
+  .linvolved { grid-template-columns: 1fr; }
+  .lhero h1 { font-size: 40px; }
+}

--- a/assessment/home.js
+++ b/assessment/home.js
@@ -1,0 +1,35 @@
+/* Landing page: render the table of contents from the shared DSOVS data. */
+(function () {
+  "use strict";
+  var DATA = window.DSOVS_DATA;
+  if (!DATA || !Array.isArray(DATA.controls)) return;
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  var groups = {};
+  DATA.phases.forEach(function (p) { groups[p] = []; });
+  DATA.controls.forEach(function (c) { (groups[c.phase] = groups[c.phase] || []).push(c); });
+
+  var toc = document.getElementById("toc");
+  if (toc) {
+    toc.innerHTML = DATA.phases.map(function (p) {
+      var list = groups[p];
+      if (!list.length) return "";
+      var chips = list.map(function (c) {
+        return '<a class="tchip" href="control.html?code=' + encodeURIComponent(c.code) + '">' +
+          '<span class="cc">' + esc(c.code) + '</span><span>' + esc(c.title) + "</span></a>";
+      }).join("");
+      return '<div class="tphase card"><div class="tphase-head"><h3>' + esc(p) +
+        '</h3><span class="c">' + list.length + " controls</span></div>" +
+        '<div class="tchips">' + chips + "</div></div>";
+    }).join("");
+  }
+
+  var stat = document.getElementById("hero-stat");
+  if (stat) {
+    stat.textContent = DATA.phases.length + " phases · " + DATA.controls.length + " controls · 4 maturity levels";
+  }
+})();

--- a/assessment/index.html
+++ b/assessment/index.html
@@ -3,79 +3,100 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>DSOVS Self-Assessment</title>
-  <meta name="description" content="Self-assess your software development lifecycle against the OWASP DevSecOps Verification Standard. Everything stays in your browser." />
+  <title>OWASP DevSecOps Verification Standard</title>
+  <meta name="description" content="An open-source framework to identify gaps in implementing security across the software development lifecycle." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="home.css" />
 </head>
 <body>
   <header class="topbar">
     <div class="topbar-inner">
-      <div class="brand">
+      <a class="brand" href="index.html">
+        <img class="brand-logo" src="https://upload.wikimedia.org/wikipedia/commons/e/ef/OWASP_black_logo.svg" alt="OWASP" width="86" height="28" />
+        <span class="brand-divider" aria-hidden="true"></span>
         <span class="brand-mark">DSOVS</span>
         <span class="brand-sub">DevSecOps Verification Standard</span>
-      </div>
-      <nav class="view-switch" aria-label="Views">
-        <button class="seg" data-view="assess" aria-pressed="true">Assessment</button>
-        <button class="seg" data-view="report" aria-pressed="false">Report</button>
+      </a>
+      <nav class="top-actions" aria-label="Primary">
+        <a class="toplink" href="#standard">The standard</a>
+        <a class="toplink" href="https://github.com/OWASP/www-project-devsecops-verification-standard" target="_blank" rel="noopener">GitHub</a>
+        <a class="btn primary sm" href="assess.html">Self-Assessment</a>
       </nav>
     </div>
   </header>
 
-  <main class="wrap">
-    <!-- ASSESSMENT VIEW -->
-    <section id="view-assess">
-      <div class="hero">
-        <h1>Self-Assessment</h1>
-        <p class="lede">Rate each control against the four DSOVS maturity levels, capture evidence and notes, then generate a report. Your answers never leave this browser &mdash; they are saved locally on this device.</p>
+  <main class="lwrap">
+    <section class="lhero">
+      <span class="lpill">OWASP Project</span>
+      <h1>The DevSecOps Verification Standard</h1>
+      <p class="lhero-sub">An open-source framework that defines baseline security requirements for any software project or organisation, so you can find the gaps in your secure development lifecycle and chart a path to close them.</p>
+      <div class="lhero-cta">
+        <a class="btn primary" href="assess.html">Start the self-assessment &rarr;</a>
+        <a class="btn ghost" href="#standard">Explore the standard</a>
       </div>
+      <div class="lhero-stat" id="hero-stat">7 phases &middot; 39 controls &middot; 4 maturity levels</div>
+    </section>
 
-      <div class="setup card">
-        <div class="field">
-          <label for="org">Organisation / project</label>
-          <input id="org" type="text" placeholder="e.g. Acme Payments" autocomplete="off" />
-        </div>
-        <div class="field">
-          <label for="assessor">Assessor</label>
-          <input id="assessor" type="text" placeholder="Your name" autocomplete="off" />
-        </div>
-        <div class="field">
-          <label for="date">Date</label>
-          <input id="date" type="date" />
-        </div>
-        <div class="field">
-          <label for="target">Target level</label>
-          <select id="target">
-            <option value="1">Level 1</option>
-            <option value="2" selected>Level 2</option>
-            <option value="3">Level 3</option>
-          </select>
-        </div>
+    <section class="luse">
+      <div class="lcard card">
+        <h3>Gap Analysis</h3>
+        <p>Identify the gaps in one or many software projects by giving internal or external analysts a clearly defined standard that covers every area of the secure development lifecycle.</p>
       </div>
-
-      <div class="progress-bar card" id="progress">
-        <div class="progress-meta">
-          <span id="progress-count">0 of 0 assessed</span>
-          <span id="progress-pct" class="muted">0%</span>
-        </div>
-        <div class="track"><div class="fill" id="progress-fill" style="width:0%"></div></div>
+      <div class="lcard card">
+        <h3>Maturity Roadmap</h3>
+        <p>Developers, architects and security teams can pinpoint their current DevSecOps maturity and map a clear path toward a higher, measurable level.</p>
       </div>
-
-      <nav class="phase-nav" id="phase-nav" aria-label="Jump to phase"></nav>
-
-      <div id="controls"></div>
-
-      <div class="footer-actions">
-        <button class="btn ghost" id="reset">Reset all answers</button>
-        <button class="btn primary" id="goto-report">Generate report &rarr;</button>
+      <div class="lcard card">
+        <h3>Third-party Risk</h3>
+        <p>Audit the SDLC maturity of third parties to confirm their development processes are resilient and to surface risks arising from people, processes or software.</p>
       </div>
     </section>
 
-    <!-- REPORT VIEW -->
-    <section id="view-report" hidden>
-      <div id="report"></div>
+    <section class="lband card">
+      <div class="lband-text">
+        <h2>Assess yourself in the browser</h2>
+        <p>Rate every control against the four maturity levels, attach screenshots as evidence, and generate a shareable report - an executive summary, maturity charts, a prioritised roadmap and an evidence pack. Everything stays on your device.</p>
+        <a class="btn primary" href="assess.html">Open the self-assessment &rarr;</a>
+      </div>
+      <div class="lband-levels" aria-hidden="true">
+        <div class="llv"><span>0</span>Initial</div>
+        <div class="llv"><span>1</span>Basic</div>
+        <div class="llv"><span>2</span>Managed</div>
+        <div class="llv"><span>3</span>Optimised</div>
+      </div>
+    </section>
+
+    <section id="standard" class="lstandard">
+      <div class="lsec-head">
+        <h2>The standard</h2>
+        <p>Controls are grouped by lifecycle phase. Each defines four maturity levels, from absent (0) through to measured and continuously improved (3). Open any control to read its full definition.</p>
+      </div>
+      <div id="toc" class="toc"></div>
+    </section>
+
+    <section class="linvolved">
+      <div class="lcard card">
+        <h3>Get involved</h3>
+        <p>The DSOVS evolves as processes and technologies change. Contributions and feedback are welcome.</p>
+        <ul class="llist">
+          <li><a href="https://github.com/OWASP/www-project-devsecops-verification-standard/issues" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 2 1.88 1.88"/><path d="M14.12 3.88 16 2"/><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1"/><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"/><path d="M12 20v-9"/><path d="M6.53 9C4.6 8.8 3 7.1 3 5"/><path d="M6 13H2"/><path d="M3 21c0-2.1 1.7-3.9 3.8-4"/><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4"/><path d="M22 13h-4"/><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4"/></svg><span>Report errors (typos, grammar)</span></a></li>
+          <li><a href="https://github.com/OWASP/www-project-devsecops-verification-standard/pulls" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg><span>Propose changes with a pull request</span></a></li>
+          <li><a href="https://github.com/OWASP/www-project-devsecops-verification-standard/discussions/categories/q-a" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg><span>Ask questions</span></a></li>
+          <li><a href="https://github.com/OWASP/www-project-devsecops-verification-standard/discussions/categories/ideas" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg><span>Share new ideas</span></a></li>
+        </ul>
+      </div>
+      <div class="lcard card">
+        <h3>Connect with us</h3>
+        <p>Join the community and be part of the journey.</p>
+        <ul class="llist">
+          <li><a href="https://owasp.slack.com/messages/project-devsecops-verification-standard/details/" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="20" y1="9" y2="9"/><line x1="4" x2="20" y1="15" y2="15"/><line x1="10" x2="8" y1="3" y2="21"/><line x1="16" x2="14" y1="3" y2="21"/></svg><span>#project-devsecops-verification-standard</span></a></li>
+          <li><a href="https://www.linkedin.com/in/theonejvo/" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg><span>Jamieson Vincenti O'Reilly - Project Lead</span></a></li>
+          <li><a href="https://www.linkedin.com/in/yudhiy/" target="_blank" rel="noopener"><svg class="li-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg><span>Yudhi Yudhistira - Project Lead</span></a></li>
+        </ul>
+      </div>
     </section>
   </main>
 
@@ -85,6 +106,6 @@
   </footer>
 
   <script src="data.js"></script>
-  <script src="app.js"></script>
+  <script src="home.js"></script>
 </body>
 </html>

--- a/assessment/styles.css
+++ b/assessment/styles.css
@@ -20,7 +20,7 @@
 
 * { box-sizing: border-box; }
 
-html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; scroll-behavior: smooth; }
 
 body {
   margin: 0;
@@ -51,9 +51,20 @@ body {
   justify-content: space-between;
   gap: 16px;
 }
-.brand { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
-.brand-mark { font-weight: 600; font-size: 17px; letter-spacing: 0.02em; }
+.brand { display: flex; align-items: center; gap: 10px; min-width: 0; text-decoration: none; color: inherit; }
+.brand-logo { height: 26px; width: auto; display: block; }
+.brand-divider { width: 1px; height: 20px; background: var(--border); display: inline-block; }
+.brand-mark { font-weight: 600; font-size: 17px; letter-spacing: 0.02em; color: var(--text); }
 .brand-sub { color: var(--text-3); font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* Top-right cluster + reset */
+.top-right { display: flex; align-items: center; gap: 14px; }
+.topreset {
+  font-family: inherit; font-size: 13px; font-weight: 500; color: var(--text-2);
+  background: transparent; border: 1px solid var(--border); border-radius: 980px;
+  padding: 6px 14px; cursor: pointer; transition: all .15s ease;
+}
+.topreset:hover { color: var(--text); border-color: var(--text-3); }
 
 /* Segmented view switch */
 .view-switch { display: inline-flex; background: var(--bg-subtle); border-radius: 980px; padding: 3px; gap: 2px; }
@@ -104,13 +115,28 @@ body {
 .track { height: 6px; background: var(--bg-subtle); border-radius: 980px; overflow: hidden; }
 .fill { height: 100%; background: var(--black); border-radius: 980px; transition: width .3s ease; }
 
-/* Phase nav */
-.phase-nav { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px; }
+/* Fixed left rail (wide screens) */
+.rail { display: none; }
+.rail-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); padding: 0 10px 8px; }
+.rail ol { list-style: none; margin: 0; padding: 0; }
+.rail a {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  font-size: 13px; color: var(--text-2); text-decoration: none;
+  padding: 7px 10px; border-radius: 8px; transition: all .12s ease;
+}
+.rail a:hover { color: var(--text); background: var(--card); }
+.rail a.active { color: var(--text); font-weight: 600; background: var(--card); }
+.rail a .rl { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rail a .c { font-family: var(--mono); font-size: 11px; color: var(--text-3); flex: none; }
+
+/* Phase nav (compact / narrow screens) */
+.phase-nav { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px; position: sticky; top: 116px; z-index: 15; background: var(--bg-subtle); padding: 8px 0; }
 .phase-nav a {
   font-size: 13px; font-weight: 500; color: var(--text-2); text-decoration: none;
   border: 1px solid var(--border-subtle); background: var(--card); padding: 6px 12px; border-radius: 980px; transition: all .15s ease;
 }
 .phase-nav a:hover { color: var(--text); border-color: var(--border); }
+.phase-nav a.active { color: var(--text); border-color: var(--text); font-weight: 600; }
 .phase-nav a .n { color: var(--text-3); margin-left: 6px; }
 
 /* Phase section */
@@ -160,11 +186,37 @@ body {
 .notes label { font-size: 12px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.04em; display: block; margin-bottom: 6px; }
 textarea { resize: vertical; min-height: 56px; }
 
+/* Evidence screenshots (assessment) */
+.figures { margin-top: 16px; border-top: 1px solid var(--border-subtle); padding-top: 14px; }
+.fig-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.btn-mini { font-size: 12px; font-weight: 500; color: var(--text); border: 1px solid var(--border); border-radius: 980px; padding: 5px 13px; cursor: pointer; background: var(--card); transition: border-color .15s ease; }
+.btn-mini:hover { border-color: var(--text-3); }
+.fig-list { display: flex; flex-direction: column; gap: 10px; }
+.fig-empty { font-size: 13px; color: var(--text-3); margin: 0; border: 1px dashed var(--border); border-radius: var(--radius-sm); padding: 16px; text-align: center; }
+.fig { display: grid; grid-template-columns: 104px 1fr; gap: 12px; align-items: start; }
+.fig-thumb { width: 104px; height: 68px; object-fit: cover; border-radius: 8px; border: 1px solid var(--border-subtle); background: var(--bg-subtle); }
+.fig-meta { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.fig-del { align-self: flex-start; font-size: 12px; color: var(--text-2); background: transparent; border: 0; padding: 0; cursor: pointer; text-decoration: underline; }
+.fig-del:hover { color: var(--text); }
+
+/* Evidence figures (report) */
+.evidence-block { padding: 18px 22px; margin-bottom: 12px; }
+.ev-ctl { font-family: var(--mono); font-size: 12px; color: var(--text-3); margin-bottom: 14px; }
+.figure { margin: 0 0 20px; }
+.figure:last-child { margin-bottom: 0; }
+.figure img { width: 100%; max-width: 600px; border: 1px solid var(--border-subtle); border-radius: 10px; display: block; }
+.figure figcaption { font-size: 13.5px; color: var(--text-2); margin-top: 9px; line-height: 1.45; }
+.figure figcaption b { color: var(--text); font-weight: 600; }
+.fig-missing { font-size: 12px; color: var(--text-3); padding: 22px; background: var(--bg-subtle); border-radius: 10px; text-align: center; }
+.gap-figref { margin-top: 10px; font-size: 13px; color: var(--text-2); }
+
 /* Buttons */
 .btn {
   font-family: inherit; font-size: 15px; font-weight: 500; border-radius: 980px;
   padding: 11px 22px; cursor: pointer; border: 1px solid transparent; transition: all .15s ease;
+  text-decoration: none; display: inline-block; text-align: center;
 }
+.btn:hover { text-decoration: none; }
 .btn.primary { background: var(--black); color: #fff; }
 .btn.primary:hover { background: #000; }
 .btn.ghost { background: transparent; color: var(--text-2); border-color: var(--border); }
@@ -172,10 +224,17 @@ textarea { resize: vertical; min-height: 56px; }
 .footer-actions { display: flex; justify-content: space-between; align-items: center; margin-top: 32px; gap: 12px; }
 
 /* Report */
+#report { max-width: 820px; margin: 0 auto; }
+.report-intro { margin: 0 0 28px; }
+.report-intro p { font-size: 17px; line-height: 1.6; color: var(--text-2); margin: 0 0 12px; max-width: 68ch; }
+.report-intro p:first-child { color: var(--text); }
+.report-intro p:last-child { margin-bottom: 0; }
+#report .card, #report .gap, #report .stat { overflow-wrap: anywhere; }
 .report-head { margin-bottom: 28px; }
 .report-head h1 { font-size: 34px; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 6px; }
 .report-meta { color: var(--text-2); font-size: 15px; }
 .report-meta span + span::before { content: "\00b7"; margin: 0 8px; color: var(--text-3); }
+.report-meta .rid { font-family: var(--mono); font-size: 13px; color: var(--text-3); }
 
 .stat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-bottom: 28px; }
 .stat { padding: 22px; text-align: left; }
@@ -183,6 +242,34 @@ textarea { resize: vertical; min-height: 56px; }
 .stat .lab { font-size: 13px; color: var(--text-2); margin-top: 8px; }
 
 .section-title { font-size: 13px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.05em; margin: 32px 4px 14px; }
+.section-lead { font-size: 14px; color: var(--text-2); line-height: 1.55; margin: -4px 4px 16px; max-width: 64ch; }
+.gap-why { font-size: 13.5px; color: var(--text-2); line-height: 1.5; margin-top: 8px; }
+
+/* Charts */
+.charts { display: grid; grid-template-columns: 190px 1fr; gap: 8px; align-items: center; padding: 24px 22px; }
+.donut-wrap { text-align: center; }
+.donut { width: 130px; height: 130px; }
+.donut .d-track { fill: none; stroke: var(--bg-subtle); stroke-width: 11; }
+.donut .d-val { fill: none; stroke: var(--black); stroke-width: 11; stroke-linecap: round; }
+.donut .d-num { font: 600 28px var(--font); fill: var(--text); letter-spacing: -0.02em; }
+.donut .d-sub { font: 500 10px var(--font); fill: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; }
+.donut-cap { font-size: 13px; color: var(--text-2); margin-top: 6px; }
+.radar-wrap { min-width: 0; }
+.radar { width: 100%; max-width: 380px; height: auto; display: block; margin: 0 auto; }
+.radar .ring { fill: none; stroke: var(--border-subtle); stroke-width: 1; }
+.radar .axis { stroke: var(--border-subtle); stroke-width: 1; }
+.radar .r-data { fill: rgba(29,29,31,0.10); stroke: var(--black); stroke-width: 1.5; stroke-linejoin: round; }
+.radar .r-dot { fill: var(--black); }
+.radar .r-label { font: 500 11px var(--font); fill: var(--text-2); }
+
+/* Pipeline flow */
+.pipeline { padding: 22px; }
+.pl-row { display: flex; align-items: stretch; gap: 0; overflow-x: auto; }
+.pl-stage { flex: 1 1 0; min-width: 64px; border-radius: 10px; padding: 14px 8px; text-align: center; }
+.pl-name { font-size: 11px; font-weight: 500; letter-spacing: 0.02em; opacity: 0.88; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pl-val { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin-top: 3px; }
+.pl-arrow { flex: 0 0 auto; align-self: center; color: var(--text-3); font-size: 18px; padding: 0 5px; }
+.pl-cap { font-size: 12.5px; color: var(--text-3); margin-top: 14px; text-align: center; }
 
 /* Phase bars */
 .bars { padding: 8px 22px 18px; }
@@ -196,7 +283,8 @@ textarea { resize: vertical; min-height: 56px; }
 /* Gap list */
 .gap { padding: 18px 22px; margin-bottom: 12px; }
 .gap-top { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
-.gap-top .g-id { font-family: var(--mono); font-size: 12px; color: var(--text-3); }
+.g-id { display: inline-block; font-family: var(--mono); font-size: 12px; color: var(--text-3); text-decoration: none; }
+a.g-id:hover { color: var(--text); text-decoration: underline; }
 .gap-top .g-title { font-size: 16px; font-weight: 600; margin: 2px 0 0; }
 .gap-move { font-size: 13px; color: var(--text-2); white-space: nowrap; }
 .gap-move b { color: var(--text); font-weight: 600; }
@@ -221,6 +309,18 @@ textarea { resize: vertical; min-height: 56px; }
 .sitefoot a { color: var(--text-2); text-decoration: none; }
 .sitefoot a:hover { color: var(--text); }
 
+/* Wide screens: show the fixed left rail, hide the inline nav */
+@media (min-width: 1320px) {
+  .rail {
+    display: block;
+    position: fixed;
+    top: 140px;
+    left: max(20px, calc((100vw - var(--maxw)) / 2 - 196px));
+    width: 176px;
+  }
+  .phase-nav { display: none; }
+}
+
 /* Responsive */
 @media (max-width: 720px) {
   .setup { grid-template-columns: repeat(2, 1fr); }
@@ -230,14 +330,27 @@ textarea { resize: vertical; min-height: 56px; }
   .level-seg button .lbl { display: none; }
   .bar-row { grid-template-columns: 110px 1fr 40px; }
   .brand-sub { display: none; }
+  .charts { grid-template-columns: 1fr; gap: 16px; }
+  .donut-wrap { margin-bottom: 4px; }
 }
 
 /* Print */
+@page { margin: 0; }
 @media print {
-  .topbar, .phase-nav, .footer-actions, .report-actions, .sitefoot, #view-assess { display: none !important; }
-  body { background: #fff; }
-  .wrap { padding: 0; max-width: none; }
+  .topbar, .rail, .phase-nav, .footer-actions, .report-actions, .sitefoot, #view-assess { display: none !important; }
+  html, body { background: #fff; }
+  /* gutter is baked into the content as padding so it survives any "Margins" print setting */
+  .wrap { padding: 10mm 16mm 14mm; max-width: none; margin: 0; }
+  #report { max-width: 100%; margin: 0; padding: 0; }
+  .report-intro p { max-width: none; }
+  /* keep shaded pipeline / fills when printing regardless of "background graphics" */
+  .pl-stage, .donut, .radar, .fill, .bar-val { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
   .card { box-shadow: none; border: 1px solid #ddd; break-inside: avoid; }
-  .gap, .stat, .bars { break-inside: avoid; }
+  .stat-grid { gap: 10px; }
+  .gap, .stat, .bars, .pipeline, .figure, .evidence-block, .charts { break-inside: avoid; }
+  /* padding (not margin) survives page breaks, so a heading pushed to a new page keeps its top gutter */
+  .section-title { break-after: avoid; page-break-after: avoid; margin-top: 0; padding-top: 12mm; }
+  .report-head, .report-intro { break-after: avoid; }
+  .figure img { max-width: 100%; }
   a { color: #000 !important; text-decoration: none; }
 }

--- a/index.md
+++ b/index.md
@@ -33,7 +33,7 @@ Building your own tooling? Every control is also published as machine-readable d
 ## 💬 Connect with Us
 
 <li><a href="https://owasp.slack.com/messages/project-devsecops-verification-standard/details/"><img src="document/images/slack_logo.png" width="14px">  #project-devsecops-verification-standard</a></li>
-<li><a href="https://www.linkedin.com/in/realjvo/"><img src="document/images/linkedin.svg" width="14px"> @realjvo </a> (Jamieson Vincenti O'Reilly, Project Lead)</li><li><a href="https://www.linkedin.com/in/yudhiy/"><img src="document/images/linkedin.svg" width="14px"> @yudhiy </a> (Yudhi Yudhistira, Project Lead)</li>
+<li><a href="https://www.linkedin.com/in/theonejvo/"><img src="document/images/linkedin.svg" width="14px"> @theonejvo </a> (Jamieson Vincenti O'Reilly, Project Lead)</li><li><a href="https://www.linkedin.com/in/yudhiy/"><img src="document/images/linkedin.svg" width="14px"> @yudhiy </a> (Yudhi Yudhistira, Project Lead)</li>
 
 ## 🎉 Get Involved
 


### PR DESCRIPTION
Build out the browser app around the self-assessment so it reads like a product, all generated from the same source of truth (no content drift):

- Landing page (assessment/index.html) in the shared design: hero, the three DSOVS use cases, a self-assessment highlight, and a table of contents that lists every control from data.js.
- A rendered page per control (assessment/control.html?code=...) showing the summary, the four maturity levels with their diagrams and verification evidence, notable tools with code samples, framework mappings, further reading and credits - so control links open in this UI instead of GitHub.
- Self-assessment (assessment/assess.html): report now opens with a prose executive summary, three charts (overall donut, per-phase radar and a left-to-right pipeline-flow heatmap), a prioritised roadmap with one-line rationale and the next step, screenshot evidence rendered as numbered Figures, a content-hash Report ID, and report-specific PDF/JSON filenames.
- Shared top bar with a clickable OWASP/DSOVS brand, a Reset control that wipes local data, real (Lucide) icons, and fixed print margins.

Also point the project LinkedIn link to /in/theonejvo, and ignore Cloudflare and environment files so deploy secrets are never committed.